### PR TITLE
Adiciona navegação sequencial entre as páginas do livro

### DIFF
--- a/docs/javascripts/navegacao.js
+++ b/docs/javascripts/navegacao.js
@@ -1,0 +1,112 @@
+/* ==========================================================================
+   Ler o livro com as teclas de movimento do Vim.
+
+     h  [    página anterior      j   desce uma linha
+     l  ]    próxima página       k   sobe uma linha
+
+   n/p (e ./,) já vinham do tema e continuam valendo. Ctrl+J e Ctrl+K também
+   são dele — nada com Ctrl/Cmd chega até aqui.
+   ========================================================================== */
+
+const DIRECOES = {
+  h: "prev",
+  "[": "prev",
+  l: "next",
+  "]": "next",
+}
+
+const ROLAGEM = {
+  j: 1,
+  k: -1,
+}
+
+/*
+ * O link do rodapé é um <a> de verdade, que o roteador do tema intercepta;
+ * clicar nele preserva a navegação instantânea. O <link rel> do <head> é o
+ * reserva para quando o rodapé está oculto por `hide: [footer]`.
+ */
+function alvo(direcao) {
+  return (
+    document.querySelector(`.md-footer__link--${direcao}`) ||
+    document.querySelector(`link[rel=${direcao}]`)
+  )
+}
+
+/* Uma linha de texto, medida no elemento real para acompanhar o zoom e a
+   fonte que o leitor escolheu. */
+function alturaDaLinha() {
+  const conteudo = document.querySelector(".md-content__inner")
+  if (!conteudo) return 24
+
+  const estilo = getComputedStyle(conteudo)
+  const linha = parseFloat(estilo.lineHeight)
+  if (Number.isFinite(linha)) return linha
+
+  const fonte = parseFloat(estilo.fontSize)
+  return Number.isFinite(fonte) ? fonte * 1.6 : 24
+}
+
+/*
+ * keyboard$ traz de graça as guardas do tema: não dispara com a busca aberta,
+ * dentro de campos de texto, nem no meio de uma composição de acentos.
+ */
+if (window.keyboard$) {
+  window.keyboard$.subscribe((tecla) => {
+    if (tecla.mode !== "global" || tecla.meta) return
+
+    const direcao = DIRECOES[tecla.type]
+    if (direcao) {
+      const destino = alvo(direcao)
+      if (!destino) return
+
+      tecla.claim()
+      if (destino.tagName === "A") destino.click()
+      else location.assign(destino.href)
+      return
+    }
+
+    /* Sem animação: o Vim não anima, e segurar a tecla precisa deslizar
+       contínuo em vez de enfileirar transições. */
+    const sentido = ROLAGEM[tecla.type]
+    if (sentido) {
+      tecla.claim()
+      window.scrollBy(0, sentido * alturaDaLinha())
+    }
+  })
+}
+
+/*
+ * A dica só aparece se este script rodou — anunciada pelo template, seria
+ * mentira com o JS desligado. E reaparece a cada troca de página, porque a
+ * navegação instantânea substitui o rodapé inteiro.
+ */
+function anunciaAtalhos() {
+  const navegacao = document.querySelector(".md-footer__inner")
+  if (!navegacao || navegacao.parentElement.querySelector(".vimbook-atalhos")) {
+    return
+  }
+
+  const dica = document.createElement("p")
+  dica.className = "vimbook-atalhos"
+  dica.append(
+    tecla("h"),
+    tecla("l"),
+    " virar a página · ",
+    tecla("j"),
+    tecla("k"),
+    " rolar",
+  )
+  navegacao.after(dica)
+}
+
+function tecla(nome) {
+  const kbd = document.createElement("kbd")
+  kbd.textContent = nome
+  return kbd
+}
+
+if (window.document$) {
+  window.document$.subscribe(anunciaAtalhos)
+} else {
+  document.addEventListener("DOMContentLoaded", anunciaAtalhos)
+}

--- a/docs/stylesheets/vimbook.css
+++ b/docs/stylesheets/vimbook.css
@@ -135,3 +135,38 @@
 [data-md-color-scheme="slate"] ::selection {
   background: #00ae0040;
 }
+
+/* --------------------------------------------------------------------------
+   A dica de atalhos abaixo do "anterior / próxima" do rodapé.
+
+   Discreta de propósito — só precisa ser notada uma vez. Mesmo assim o cinza
+   dá 4,6:1 no claro e 5,3:1 no escuro. Some onde não há teclado físico.
+   -------------------------------------------------------------------------- */
+
+.vimbook-atalhos {
+  margin: 0;
+  padding: 0 0.8rem 0.8rem;
+  color: var(--md-footer-fg-color--light);
+  font-size: 0.64rem;
+  text-align: center;
+}
+
+.vimbook-atalhos kbd {
+  display: inline-block;
+  min-width: 1.4em;
+  margin: 0 0.1em;
+  padding: 0.1em 0.35em;
+  border: 1px solid var(--md-footer-fg-color--lighter);
+  border-radius: 0.15rem;
+  color: var(--md-footer-fg-color);
+  font-family: var(--md-code-font-family, monospace);
+  font-size: 0.9em;
+  line-height: 1.4;
+  text-align: center;
+}
+
+@media (hover: none), (pointer: coarse) {
+  .vimbook-atalhos {
+    display: none;
+  }
+}

--- a/zensical.toml
+++ b/zensical.toml
@@ -4,6 +4,7 @@ site_url = "https://cassiobotaro.dev/vimbook/"
 repo_name = "cassiobotaro/vimbook"
 repo_url = "https://github.com/cassiobotaro/vimbook"
 extra_css = ["stylesheets/vimbook.css"]
+extra_javascript = ["javascripts/navegacao.js"]
 
 nav = [
   { "O EDITOR DE TEXTO VIM" = "index.md" },
@@ -223,7 +224,25 @@ nav = [
 variant = "classic"
 language = "pt"
 favicon = "imgs/favicon.ico"
-features = ["content.tabs.link"]
+
+# Um livro se lê em sequência, então a leitura não pode depender só do menu
+# lateral. O rodapé "anterior / próxima" dá o seguir em frente — e é dele que
+# os atalhos de teclado saem; a trilha (navigation.path) dá o "onde estou".
+#
+# Fica de fora "navigation.indexes": ele só reconhece como abertura de seção
+# um arquivo chamado index.md, e aqui as aberturas de capítulo têm nome
+# próprio (capitulo_1/introducao.md). A trilha chega ao mesmo lugar de todo
+# jeito, porque na falta de um índice ela usa o primeiro item do capítulo.
+features = [
+  "content.tabs.link",
+  "navigation.footer",
+  "navigation.path",
+  "navigation.instant",
+  "navigation.instant.progress",
+  "navigation.top",
+  "navigation.tracking",
+  "toc.follow",
+]
 
 [project.theme.icon]
 logo = "material/book"


### PR DESCRIPTION
Hoje a leitura em ordem depende do menu lateral. Este PR dá ao livro os dois eixos que faltavam: seguir em frente e saber onde se está.

- Liga `navigation.footer`, que põe os links **anterior / próxima** ao fim de cada página.
- Adiciona `docs/javascripts/navegacao.js` com as teclas de movimento do Vim:

  | | |
  |---|---|
  | `h` `[` | página anterior |
  | `l` `]` | próxima página |
  | `j` | desce uma linha |
  | `k` | sobe uma linha |

  O tema já mapeava `n`/`p` (e `.`/`,`) sobre os `<link rel="prev|next">` do `<head>`, mas eram atalhos invisíveis. Agora há a dica no rodapé.
- Liga também `navigation.path` (trilha do capítulo acima do título, que leva à abertura dele), `navigation.instant`, `navigation.top`, `navigation.tracking` e `toc.follow`.

### Detalhes

O script não calcula qual é a página vizinha: clica no `<a>` do rodapé, que o roteador do tema intercepta, preservando a navegação instantânea. Usa o `keyboard$` do tema e herda as guardas dele, então nada dispara com a busca aberta, dentro de campos de texto ou no meio de uma composição de acentos. `Ctrl+J` e `Ctrl+K` continuam sendo do tema.

A dica das teclas é injetada pelo JS, e não pelo template, porque sem o script ela seria uma promessa falsa. Some em telas sem teclado físico.

Ficou de fora o `navigation.indexes`: ele só reconhece como abertura de seção um arquivo chamado `index.md`, e aqui as aberturas de capítulo têm nome próprio (`capitulo_1/introducao.md`). Fazer a opção valer exigiria renomear 15 arquivos e mudar as URLs deles. A trilha chega ao mesmo lugar de todo jeito, porque na falta de um índice ela usa o primeiro item do capítulo.

### Verificação

- Seguindo só o "próxima" a partir da capa se alcança as **179 páginas, sem órfãs**, com os elos anterior/próxima consistentes nos dois sentidos e as 15 viradas de capítulo caindo na abertura do capítulo seguinte.
- As URLs geradas continuam **idênticas** às de antes — nenhum link quebrado.
- O JS foi exercitado em 20 casos contra um DOM simulado (teclas mapeadas e ignoradas, busca aberta, `Ctrl`+tecla, capa sem "anterior", última página sem "próxima", passo acompanhando o `line-height`, dica não duplicando entre trocas de página).

Não consegui testar em navegador de verdade nesta máquina; vale conferir com `zensical serve` antes de mesclar.
