### PR TITLE
Remove o título repetido de 69 páginas

### DIFF
--- a/docs/capitulo_1/entrando_em_modo_de_edicao.md
+++ b/docs/capitulo_1/entrando_em_modo_de_edicao.md
@@ -2,9 +2,6 @@
 title: Entrando em modo de edição
 ---
 
-Entrando em modo de edição
---------------------------
-
 Estando no modo normal, digita-se:
 ```
 a .... inicia inserção de texto após o caractere atual

--- a/docs/capitulo_1/modos_de_operacao.md
+++ b/docs/capitulo_1/modos_de_operacao.md
@@ -2,9 +2,6 @@
 title: Modos de operação
 ---
 
-Modos de operação
------------------
-
 A tabela abaixo mostra uma referência rápida para os modos de operação
 do Vim, a seguir mais detalhes sobre cada um dos modos.
 

--- a/docs/capitulo_10/comandos_relativos_a_verificacao_ortografica.md
+++ b/docs/capitulo_10/comandos_relativos_a_verificacao_ortografica.md
@@ -2,9 +2,6 @@
 title: Comandos relativos à verificação ortográfica
 ---
 
-Comandos relativos à verificação ortográfica
---------------------------------------------
-
 ### Encontrando palavras desconhecidas
 
 Muito embora o verificador ortográfico cheque imediatamente cada palavra

--- a/docs/capitulo_10/dicionario_de_termos.md
+++ b/docs/capitulo_10/dicionario_de_termos.md
@@ -2,9 +2,6 @@
 title: O dicionário de termos
 ---
 
-O dicionário de termos
-----------------------
-
 A qualidade da verificação ortográfica do Vim está diretamente ligada à
 completude e corretude do dicionário da linguagem em questão.
 Dicionários pouco completos são inconvenientes à medida que acusam falso

--- a/docs/capitulo_10/habilitando_a_verificacao_ortografica.md
+++ b/docs/capitulo_10/habilitando_a_verificacao_ortografica.md
@@ -2,9 +2,6 @@
 title: Habilitando a verificação ortográfica
 ---
 
-Habilitando a verificação ortográfica
--------------------------------------
-
 A verificação ortográfica atua em uma linguagem (dicionário) por vez,
 portanto, sua efetiva habilitação depende da especificação desta
 linguagem. Por exemplo, para habilitar no arquivo em edição a

--- a/docs/capitulo_11/criando_sessoes.md
+++ b/docs/capitulo_11/criando_sessoes.md
@@ -2,9 +2,6 @@
 title: Criando sessões
 ---
 
-Criando sessões
----------------
-
 Sessões são criadas através do comando `:mksession`:
 ```
 :mks[ession] sessao.vim .... cria a sessão e armazena-a em sessao.vim

--- a/docs/capitulo_11/o_que_uma_sessao_armazena.md
+++ b/docs/capitulo_11/o_que_uma_sessao_armazena.md
@@ -2,9 +2,6 @@
 title: O que uma sessão armazena?
 ---
 
-O que uma sessão armazena?
---------------------------
-
 Uma sessão é composta das seguintes informações:
 
 -   Mapeamentos globais

--- a/docs/capitulo_11/restaurando_sessoes.md
+++ b/docs/capitulo_11/restaurando_sessoes.md
@@ -2,9 +2,6 @@
 title: Restaurando sessões
 ---
 
-Restaurando sessões
--------------------
-
 Após gravar sessões, elas podem ser carregadas ao iniciar o Vim:
 ```
 vim -S sessao.vim

--- a/docs/capitulo_12/abreviacoes.md
+++ b/docs/capitulo_12/abreviacoes.md
@@ -2,9 +2,6 @@
 title: Abreviações
 ---
 
-Abreviações 
------------
-
 Abreviações habilitam auto-texto para o Vim. O seu funcionamento
 consiste de três campos, o primeiro é o modo no qual a abreviação
 funcionará, o segundo é a palavra que irá disparar a abreviação e o

--- a/docs/capitulo_12/ajustando_paragrafos_em_modo_normal.md
+++ b/docs/capitulo_12/ajustando_paragrafos_em_modo_normal.md
@@ -2,9 +2,6 @@
 title: Ajustando parágrafos em modo normal
 ---
 
-Ajustando parágrafos em modo normal
------------------------------------
-
 O comando `gqap` ajusta o parágrafo atual em modo normal. Usando a
 opção *:set nojoinspaces* o vim colocará dois espaços após
 o ponto final ao se ajustar os parágrafos.

--- a/docs/capitulo_12/comentarios.md
+++ b/docs/capitulo_12/comentarios.md
@@ -2,9 +2,6 @@
 title: Comentários
 ---
 
-Comentários
------------
-
 Comentários são linhas que são ignoradas pelo interpretador Vim e servem
 normalmente para descrição de comandos e ações, deixando portanto mais
 legível e didático o arquivo de configuração. Uma linha é um comentário

--- a/docs/capitulo_12/criando_menus_para_um_modo_especifico.md
+++ b/docs/capitulo_12/criando_menus_para_um_modo_especifico.md
@@ -2,8 +2,6 @@
 title: Criando menus para um modo específico
 ---
 
-Criando menus para um modo específico 
--------------------------------------
 ```
 :menu .... Normal, Visual e Operator-pending
 :nmenu ... Modo Normal

--- a/docs/capitulo_12/exibindo_caracteres_invisiveis.md
+++ b/docs/capitulo_12/exibindo_caracteres_invisiveis.md
@@ -2,8 +2,6 @@
 title: Exibindo caracteres invisíveis
 ---
 
-Exibindo caracteres invisíveis 
-------------------------------
 ```
 :set list
 ```

--- a/docs/capitulo_12/funcoes.md
+++ b/docs/capitulo_12/funcoes.md
@@ -2,9 +2,6 @@
 title: Funções
 ---
 
-Funções
--------
-
 ### Fechamento automático de parênteses
 ```VimL
  " --------------------------------------

--- a/docs/capitulo_12/mantendo_apenas_um_gvim_aberto.md
+++ b/docs/capitulo_12/mantendo_apenas_um_gvim_aberto.md
@@ -2,9 +2,6 @@
 title: Mantendo apenas um Gvim aberto
 ---
 
-Mantendo apenas um Gvim aberto
-------------------------------
-
 Essa dica destina-se apenas à versão do Vim que roda no ambiente
 gráfico, ou seja, o Gvim, pois ela faz uso de alguns recursos que só
 funcionam nesse ambiente. A meta é criar um comando que vai abrir os

--- a/docs/capitulo_12/referencias.md
+++ b/docs/capitulo_12/referencias.md
@@ -2,8 +2,6 @@
 title: Referências
 ---
 
-Referências
------------
 -  [http://www.dicas-l.com.br/dicas-l/20050118.php](http://www.dicas-l.com.br/dicas-l/20050118.php)
 
 

--- a/docs/capitulo_13/problemas_com_codificacao_de_caracteres.md
+++ b/docs/capitulo_13/problemas_com_codificacao_de_caracteres.md
@@ -2,9 +2,6 @@
 title: Problemas com codificação de caracteres
 ---
 
-Problemas com codificação de caracteres
----------------------------------------
-
 Atualmente uso o Ubuntu em casa e ele já usa utf-8. Ao restaurar meu
 “backup” do Wiki no Kurumin os caracteres ficaram meio estranhos, daí
 fiz:

--- a/docs/capitulo_13/salvamento_automatico_para_o_wiki.md
+++ b/docs/capitulo_13/salvamento_automatico_para_o_wiki.md
@@ -2,9 +2,6 @@
 title: Salvamento automático para o Wiki
 ---
 
-Salvamento automático para o Wiki 
-----------------------------------
-
 Procure por uma seção *autowrite* no manual do Potwiki
 ```
 :help potwiki

--- a/docs/capitulo_14/edite_varios_arquivos_de_uma_so_vez.md
+++ b/docs/capitulo_14/edite_varios_arquivos_de_uma_so_vez.md
@@ -2,9 +2,6 @@
 title: Edite vários arquivos de uma só vez
 ---
 
-Edite vários arquivos de uma só vez
------------------------------------
-
 O Vim pode abrir vários arquivos que contenham um determinado padrão. Um
 exemplo seria abrir dezenas de arquivos HTML e trocar a ocorrência
 `bgcolor="ffffff"` Para `bgcolor="eeeeee"` Usaríamos a seguinte

--- a/docs/capitulo_14/mova-se_rapidamente_no_texto.md
+++ b/docs/capitulo_14/mova-se_rapidamente_no_texto.md
@@ -2,9 +2,6 @@
 title: Mova-se rapidamente no texto
 ---
 
-Mova-se rapidamente no texto
-----------------------------
-
 O capítulo [Movendo-se no Documento](../capitulo_3/movendo-se_no_documento.md),
 mostra uma série de comandos para agilizar a navegação no texto.
 Memorizando estes comandos ganha-se tempo considerável, um exemplo

--- a/docs/capitulo_14/nao_digite_duas_vezes.md
+++ b/docs/capitulo_14/nao_digite_duas_vezes.md
@@ -2,9 +2,6 @@
 title: Não digite duas vezes
 ---
 
-Não digite duas vezes
----------------------
-
 -   O Vim complementa com ‘tab’. Veja mais no capítulo [complementação com "tab"](../capitulo_12/complementacao_com_tab.md)
 
 -   Use macros. Detalhes no capítulo [gravando comandos](../capitulo_8/gravando_comandos.md).

--- a/docs/capitulo_14/referencias.md
+++ b/docs/capitulo_14/referencias.md
@@ -2,9 +2,6 @@
 title: Referências
 ---
 
-Referências
------------
-
 -   <http://www.moolenaar.net/habits_2007.pdf> por Bram Moolenaar
 
 -   <http://vim.wikia.com/wiki/Did_you_know>

--- a/docs/capitulo_14/torne_as_boas_praticas_um_habito.md
+++ b/docs/capitulo_14/torne_as_boas_praticas_um_habito.md
@@ -2,9 +2,6 @@
 title: Torne as boas práticas um hábito
 ---
 
-Torne as boas práticas um hábito 
----------------------------------
-
 Para cada prática produtiva procure adquirir um hábito e mantenha-se
 atento ao que pode ser melhorado. Imagine tarefas complexas, procure um
 meio melhor de fazer e torne um hábito.

--- a/docs/capitulo_14/use_o_file_explorer.md
+++ b/docs/capitulo_14/use_o_file_explorer.md
@@ -2,9 +2,6 @@
 title: Use o File Explorer
 ---
 
-Use o File Explorer
--------------------
-
 O Vim pode navegar em pastas assim:
 ```
 vim .

--- a/docs/capitulo_15/acessando_documentacao_do_python_no_vim.md
+++ b/docs/capitulo_15/acessando_documentacao_do_python_no_vim.md
@@ -2,9 +2,6 @@
 title: Acessando documentação do Python no Vim
 ---
 
-Acessando documentação do Python no Vim
----------------------------------------
-
 Obtenha um plugin para esta tarefa em seu
 [site oficial](http://www.vim.org/scripts/script.php?script_id=910).
 

--- a/docs/capitulo_15/atualizando_a_documentacao_dos_plugins.md
+++ b/docs/capitulo_15/atualizando_a_documentacao_dos_plugins.md
@@ -2,9 +2,6 @@
 title: Atualizando a documentação dos plugins
 ---
 
-Atualizando a documentação dos plugins
---------------------------------------
-
 Caso seja adicionado algum arquivo de documentação em `~/.vim/doc`
 pode-se gerar novamente as tags "links" para navegação de ajuda.
 

--- a/docs/capitulo_15/como_testar_um_plugin_sem_instala_lo.md
+++ b/docs/capitulo_15/como_testar_um_plugin_sem_instala_lo.md
@@ -2,8 +2,6 @@
 title: Como testar um plugin sem instalá-lo?
 ---
 
-Como testar um plugin sem instalá-lo?
--------------------------------------
 ```
 :source <path>/<plugin>
 ```

--- a/docs/capitulo_15/plugin_fuzzyfinder.md
+++ b/docs/capitulo_15/plugin_fuzzyfinder.md
@@ -2,9 +2,6 @@
 title: Plugin FuzzyFinder
 ---
 
-Plugin FuzzyFinder
-------------------
-
 Este plugin é a implementação de um recurso do editor *Texmate*[^1].
 Sua proposta é acessar de forma rápida:
 

--- a/docs/capitulo_15/plugin_para_latex.md
+++ b/docs/capitulo_15/plugin_para_latex.md
@@ -2,9 +2,6 @@
 title: Plugin para LaTeX
 ---
 
-Plugin para LaTeX
------------------
-
 Um plugin completo para *LaTeX* está acessível
 [aqui](http://vim-latex.sourceforge.net).
 Uma vez adicionado o plugin você pode inserir seus *templates* em:

--- a/docs/capitulo_15/um_wiki_para_o_vim.md
+++ b/docs/capitulo_15/um_wiki_para_o_vim.md
@@ -2,9 +2,6 @@
 title: Um wiki para o Vim
 ---
 
-Um wiki para o Vim
-------------------
-
 O "*plugin*" wikipot implementa um wiki para o Vim no qual você define um
 "link" com a notação WikiWord, onde um "link" é uma palavra que começa com
 uma letra maiúscula e tem outra letra maiúscula no meio.

--- a/docs/capitulo_2/abrindo_o_arquivo_para_edicao.md
+++ b/docs/capitulo_2/abrindo_o_arquivo_para_edicao.md
@@ -2,9 +2,6 @@
 title: Abrindo o arquivo para a edição
 ---
 
-Abrindo o arquivo para a edição
--------------------------------
-
 Portanto, a primeira coisa a fazer é abrir um arquivo. Como visto, para
 abrir um arquivo com Vim, digite em um terminal:
 ```

--- a/docs/capitulo_2/abrindo_o_ultimo_arquivo_rapidamente.md
+++ b/docs/capitulo_2/abrindo_o_ultimo_arquivo_rapidamente.md
@@ -2,9 +2,6 @@
 title: Abrindo o último arquivo rapidamente
 ---
 
-Abrindo o último arquivo rapidamente
-------------------------------------
-
 O Vim guarda um registrador para cada arquivo editado veja mais no capítulo [Registradores](../capitulo_5/registradores.md).
 ```
 '0 ........ abre o último arquivo editado

--- a/docs/capitulo_2/comparando_arquivos_com_vimdiff.md
+++ b/docs/capitulo_2/comparando_arquivos_com_vimdiff.md
@@ -2,9 +2,6 @@
 title: Comparando arquivos com o vimdiff
 ---
 
-Comparando arquivos com o vimdiff
----------------------------------
-
 O vim possui um modo para checagem de diferenças entre arquivos, é
 bastante útil especialmente para programadores, para saber quais são as
 diferenças entre dois arquivos faz-se:

--- a/docs/capitulo_2/convertendo_para_maiusculas.md
+++ b/docs/capitulo_2/convertendo_para_maiusculas.md
@@ -2,8 +2,6 @@
 title: Convertendo para maiúsculas
 ---
 
-Convertendo para maiúsculas
----------------------------
 ```
 gUU ....... converte a linha para maiúsculo
 guu ....... converte a linha para minúsculo

--- a/docs/capitulo_2/copiar_colar_deletar.md
+++ b/docs/capitulo_2/copiar_colar_deletar.md
@@ -2,9 +2,6 @@
 title: Copiar, Colar e Deletar
 ---
 
-Copiar, Colar e Deletar
------------------------
-
 No modo normal, o ato de deletar ou eliminar o texto está associado à
 letra `d`. No modo de inserção as teclas usuais também funcionam.
 ```

--- a/docs/capitulo_2/edicao_avancada_de_linhas.md
+++ b/docs/capitulo_2/edicao_avancada_de_linhas.md
@@ -2,9 +2,6 @@
 title: Edição avançada de linhas
 ---
 
-Edição avançada de linhas
--------------------------
-
 Seja o seguinte texto:
 ```
 1  este é um texto novo

--- a/docs/capitulo_2/editando_em_modo_comando.md
+++ b/docs/capitulo_2/editando_em_modo_comando.md
@@ -2,9 +2,6 @@
 title: Editando em modo de comando
 ---
 
-Editando em modo de comando
----------------------------
-
 Para mover um trecho usando o modo de comandos faça:
 ```
 :10,20m $

--- a/docs/capitulo_2/forcando_a_edicao_de_um_novo_arquivo.md
+++ b/docs/capitulo_2/forcando_a_edicao_de_um_novo_arquivo.md
@@ -2,9 +2,6 @@
 title: Forçando a edição de um novo arquivo
 ---
 
-Forçando a edição de um novo arquivo
-------------------------------------
-
 O Vim, como qualquer outro editor, é muito exigente no que se refere a
 alterações de arquivo. Ao tentar abandonar um arquivo editado e não
 salvo, o Vim irá se certificar da ação. Para abrir um novo arquivo sem

--- a/docs/capitulo_2/incrementando_numeros_em_modo_normal.md
+++ b/docs/capitulo_2/incrementando_numeros_em_modo_normal.md
@@ -2,9 +2,6 @@
 title: Incrementando números em modo normal
 ---
 
-Incrementando números em modo normal
-------------------------------------
-
 Posicione o cursor sobre um número e pressione:
 ```
 Ctrl-a ..... incrementa o número

--- a/docs/capitulo_2/lista_de_alteracoes.md
+++ b/docs/capitulo_2/lista_de_alteracoes.md
@@ -2,9 +2,6 @@
 title: Lista de alterações
 ---
 
-Lista de alterações
--------------------
-
 O Vim mantém uma lista de alterações, veremos agora como usar este
 recurso.
 ```

--- a/docs/capitulo_2/repetindo_a_digitacao_de_linhas.md
+++ b/docs/capitulo_2/repetindo_a_digitacao_de_linhas.md
@@ -2,8 +2,6 @@
 title: Repetindo a digitação de linhas
 ---
 
-Repetindo a digitação de linhas
--------------------------------
 ```
 " atalhos para o modo insert
 Ctrl-y ......... repete linha acima

--- a/docs/capitulo_2/substituindo_tabulacoes_por_espacos.md
+++ b/docs/capitulo_2/substituindo_tabulacoes_por_espacos.md
@@ -2,9 +2,6 @@
 title: Substituindo tabulações por espaços
 ---
 
-Substituindo tabulações por espaços
------------------------------------
-
 Se houver necessidade[^1] de trocar tabulações por espaços fazemos
 assim:
 ```

--- a/docs/capitulo_4/metodos_de_dobras.md
+++ b/docs/capitulo_4/metodos_de_dobras.md
@@ -2,9 +2,6 @@
 title: Métodos de dobras
 ---
 
-Métodos de dobras
-------------------
-
 O Vim tem seis modos *fold*, são eles:
 
 - Sintaxe (*syntax*)

--- a/docs/capitulo_5/como_colocar_um_pedaco_de_texto_em_um_registrador.md
+++ b/docs/capitulo_5/como_colocar_um_pedaco_de_texto_em_um_registrador.md
@@ -2,8 +2,6 @@
 title: Como colocar um pedaço de texto em um registrador?
 ---
 
-Como colocar um pedaço de texto em um registrador?
------------------------------------------------
 ```
  <Esc> ...... vai para o modo normal
  "a10j ...... coloca no registrador `a' as próximas 10 linhas `10j'

--- a/docs/capitulo_5/como_criar_um_registrador_em_modo_visual.md
+++ b/docs/capitulo_5/como_criar_um_registrador_em_modo_visual.md
@@ -2,9 +2,6 @@
 title: Como criar um registrador em modo visual?
 ---
 
-Como criar um registrador em modo visual?
---------------------------------------
-
 Inicie a seleção visual com o atalho
 ```
 Shift-v ..... seleciona linhas inteiras

--- a/docs/capitulo_5/o_registrador_sem_nome.md
+++ b/docs/capitulo_5/o_registrador_sem_nome.md
@@ -2,9 +2,6 @@
 title: O registrador sem nome ""
 ---
 
-O registrador sem nome ""
-----------------------
-
 Armazena o conteúdo de ações como:
 ```
 d ....... deleção

--- a/docs/capitulo_5/referencias.md
+++ b/docs/capitulo_5/referencias.md
@@ -2,9 +2,6 @@
 title: Referências
 ---
 
-Referências
------------
-
 -   <http://rayninfo.co.uk/vimtips.html>
 
 -   <http://aprendolatex.wordpress.com>

--- a/docs/capitulo_5/registrador_de_expressoes.md
+++ b/docs/capitulo_5/registrador_de_expressoes.md
@@ -2,8 +2,6 @@
 title: Registrador de expressões "=
 ---
 
-Registrador de expressões "=
--------------------------
 ```
 "=
 ```

--- a/docs/capitulo_5/registradores_de_buscas.md
+++ b/docs/capitulo_5/registradores_de_buscas.md
@@ -2,9 +2,6 @@
 title: Registradores de buscas "/"
 ---
 
-Registradores de buscas "/"
------------------------
-
 Se desejar inserir em uma substituição uma busca prévia, você poderia
 fazer assim em modo de comandos:
 ```

--- a/docs/capitulo_5/registradores_nomeados_de_a_ate_z_ou_a_ate_z.md
+++ b/docs/capitulo_5/registradores_nomeados_de_a_ate_z_ou_a_ate_z.md
@@ -2,9 +2,6 @@
 title: Registradores nomeados de "a até z" ou "A até Z"
 ---
 
-Registradores nomeados de "a até z" ou "A até Z"
---------------------------------------------
-
 Pode-se armazenar uma linha em modo normal assim:
 ```
 "ayy

--- a/docs/capitulo_6/corrigindo_a_indentacao_de_codigos.md
+++ b/docs/capitulo_6/corrigindo_a_indentacao_de_codigos.md
@@ -2,9 +2,6 @@
 title: Corrigindo a indentação de códigos
 ---
 
-Corrigindo a indentação de códigos
-----------------------------------------------
-
 Selecione o bloco de código, por exemplo
 ```
 vip  ..... visual ``inner paragraph'' (selecione este parágrafo)

--- a/docs/capitulo_6/dicas_da_lista_vi-br.md
+++ b/docs/capitulo_6/dicas_da_lista_vi-br.md
@@ -2,9 +2,6 @@
 title: Dicas da lista vi-br
 ---
 
-Dicas da lista vi-br
----------------------
-
 Fonte: [Grupo vi-br do yahoo](http://groups.yahoo.com/group/vi-br/message/853)
 
 Problema: Essa deve ser uma pergunta comum. Suponha o seguinte conteúdo

--- a/docs/capitulo_6/edicoes_complexas.md
+++ b/docs/capitulo_6/edicoes_complexas.md
@@ -2,9 +2,6 @@
 title: Edições complexas
 ---
 
-Edições complexas
--------------------------
-
 Trocando palavras de lugar: Posiciona-se o cursor no espaço antes da 1ª
 palavra e digita-se:
 ```

--- a/docs/capitulo_6/juncao_de_linhas_com_vim.md
+++ b/docs/capitulo_6/juncao_de_linhas_com_vim.md
@@ -2,9 +2,6 @@
 title: Junção de linhas com Vim
 ---
 
-Junção de linhas com Vim
-------------------------
-
 Fonte: [dicas-l da unicamp](http://www.dicas-l.com.br/dicas-l/20081228.php)
 Colaboração: Rubens Queiroz de Almeida
 

--- a/docs/capitulo_6/obtendo_informacoes_do_arquivo.md
+++ b/docs/capitulo_6/obtendo_informacoes_do_arquivo.md
@@ -2,8 +2,6 @@
 title: Obtendo informações do arquivo
 ---
 
-Obtendo informações do arquivo
-------------------------------
 ```
 ga ............. mostra o código do caractere em decimal hexa e octal
 ^g ............. mostra o caminho e o nome do arquivo

--- a/docs/capitulo_6/substituicoes.md
+++ b/docs/capitulo_6/substituicoes.md
@@ -2,9 +2,6 @@
 title: Substituições
 ---
 
-Substituições
-------------------
-
 Para fazer uma busca, certifique-se de que está em modo normal, em
 seguida digite use o comando ‘s’, conforme será explicado.
 

--- a/docs/capitulo_7/file_explorer.md
+++ b/docs/capitulo_7/file_explorer.md
@@ -2,9 +2,6 @@
 title: File Explorer
 ---
 
-File Explorer
--------------
-
 Para abrir o gerenciador de arquivos do Vim use:
 ```
 :Vex ............ abre o file explorer verticalmente

--- a/docs/capitulo_7/modos_de_divisao_da_janela.md
+++ b/docs/capitulo_7/modos_de_divisao_da_janela.md
@@ -2,9 +2,6 @@
 title: Modos de divisão da janela
 ---
 
-Modos de divisão da janela
---------------------------
-
 Como foi dito anteriormente, é possível visualizar mais de um buffer ao mesmo
 tempo, e isso pode ser feito utilizando *tab* ou *split*.
 

--- a/docs/capitulo_8/colocando_a_ultima_busca_em_um_comando.md
+++ b/docs/capitulo_8/colocando_a_ultima_busca_em_um_comando.md
@@ -2,9 +2,6 @@
 title: Colocando a última busca em um comando
 ---
 
-Colocando a última busca em um comando 
----------------------------------------
-
 Observação: lembre-se `Ctrl = ^`
 ```
 :^r/

--- a/docs/capitulo_8/inserindo_o_ultimo_comando.md
+++ b/docs/capitulo_8/inserindo_o_ultimo_comando.md
@@ -2,8 +2,6 @@
 title: Inserindo o último comando
 ---
 
-Inserindo o último comando 
----------------------------
 ```
 ^r:
 ```

--- a/docs/capitulo_8/para_repetir_exatamente_a_ultima_insercao.md
+++ b/docs/capitulo_8/para_repetir_exatamente_a_ultima_insercao.md
@@ -2,8 +2,6 @@
 title: Para repetir exatamente a última inserção
 ---
 
-Para repetir exatamente a última inserção 
-------------------------------------------
 ```
 i<c-a>
 ```

--- a/docs/capitulo_8/repetindo_a_digitacao_de_uma_linha.md
+++ b/docs/capitulo_8/repetindo_a_digitacao_de_uma_linha.md
@@ -2,8 +2,6 @@
 title: Repetindo a digitação de uma linha
 ---
 
-Repetindo a digitação de uma linha
------------------------------------
 ```
 modo de inserção
 Ctrl-y .......... repete a linha acima

--- a/docs/capitulo_8/repetindo_substituicoes.md
+++ b/docs/capitulo_8/repetindo_substituicoes.md
@@ -2,9 +2,6 @@
 title: Repetindo substituições
 ---
 
-Repetindo substituições 
-------------------------
-
 Caso seja feito uma substituição em um intervalo como abaixo
 ```
 :5,32s/isto/aquilo/g

--- a/docs/capitulo_9/calculadora_cientifica_com_o_vim.md
+++ b/docs/capitulo_9/calculadora_cientifica_com_o_vim.md
@@ -2,9 +2,6 @@
 title: Calculadora Científica com o Vim
 ---
 
-Calculadora Científica com o Vim
---------------------------------
-
 Para usar a função de Calculadora Científica no Vim usamos uma
 ferramenta externa, que pode ser o comando `bc` do
 GNU/Linux, ou uma linguagem de programação como *Python* ou

--- a/docs/capitulo_9/editando_comandos_longos_no_linux.md
+++ b/docs/capitulo_9/editando_comandos_longos_no_linux.md
@@ -2,9 +2,6 @@
 title: Editando comandos longos no Linux
 ---
 
-Editando comandos longos no Linux
----------------------------------
-
 É comum no ambiente GNU/Linux a necessidade de digitar comandos longos
 no terminal, para facilitar esta tarefa pode-se seguir estes passos:
 

--- a/docs/capitulo_9/editando_saidas_do_shell.md
+++ b/docs/capitulo_9/editando_saidas_do_shell.md
@@ -2,9 +2,6 @@
 title: Editando saídas do Shell
 ---
 
-Editando saídas do Shell
-------------------------
-
 Muitas vezes, precisamos manipular saídas do shell antes de enviá-las
 por e-mail, reportar ao chefe ou até mesmo salvá-las. Utilizando
 ```

--- a/docs/capitulo_9/log_do_subversion.md
+++ b/docs/capitulo_9/log_do_subversion.md
@@ -2,9 +2,6 @@
 title: Log do Subversion
 ---
 
-Log do Subversion
------------------
-
 A variável de ambiente *\$SVN\_EDITOR* pode ser usada para
 se especificar o caminho para o editor de texto de sua preferência, a
 fim de usá-lo na hora de dar um *commit* usando o

--- a/docs/capitulo_9/ordenando_removendo_linhas_duplicadas_no_vim7.md
+++ b/docs/capitulo_9/ordenando_removendo_linhas_duplicadas_no_vim7.md
@@ -2,8 +2,6 @@
 title: Ordenando e removendo linhas duplicadas no Vim 7
 ---
 
-Ordenando e removendo linhas duplicadas no Vim 7
-------------------------------------------------
 ```
 :sort u
 ```

--- a/docs/capitulo_9/referencias.md
+++ b/docs/capitulo_9/referencias.md
@@ -2,9 +2,6 @@
 title: Referências
 ---
 
-Referências
------------
-
 -   [http://www.dicas-l.com.br/dicas-l/20070119.php](http://www.dicas-l.com.br/dicas-l/20070119.php)
 
 -   [http://vim.wikia.com/wiki/Scientific_calculator](http://vim.wikia.com/wiki/Scientific_calculator)


### PR DESCRIPTION
A migração para o Zensical adicionou front matter `title:` em 100 páginas que já tinham título setext (texto sublinhado por `=` ou `-`). O tema injeta um `<h1>` a partir do front matter quando a página não tem `<h1>` próprio, e o setext gera `<h2>` — então as duas coisas apareciam, uma embaixo da outra.

Ficou mais visível depois que a trilha de navegação saiu, no #21.

### O recorte

Saem só as **69 páginas em que os dois títulos são idênticos caractere a caractere**. As outras 31 ficam intactas de propósito:

- Em **22**, o texto do livro tem marcação que o front matter perdeu:
  ```
  front matter: Efetivação das alterações no vimrc
  texto:        Efetivação das alterações no `vimrc`
  ```
  Apagar o setext perderia a formatação; apagar o front matter faria o Zensical derivar o título do nome do arquivo e perder os acentos, que foi justamente o problema resolvido na migração.

- Em **9**, a diferença é de caixa e as duas grafias são defensáveis — "Instalação do vim" contra "Instalação do Vim", "O Plugin EasyGrep" contra "O plugin EasyGrep". Em vários desses o texto do livro parece mais correto que o front matter, mas escolher qual vale é decisão de conteúdo, não de script.

### Verificação

Comparei os builds antes e depois nas 179 páginas geradas:

| | |
|---|---|
| páginas com `<h1>` alterado | 0 |
| páginas com corpo de texto alterado | 0 |
| `<h2>` no total | 160 → 91 (removidos 69) |

Os 69 `<h2>` removidos batem exatamente com os 69 arquivos editados.