### PR TITLE
Faz a regra de tamanho do menu lateral valer de fato

### DIFF
--- a/docs/stylesheets/vimbook.css
+++ b/docs/stylesheets/vimbook.css
@@ -221,11 +221,16 @@ body {
   font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
-.md-nav {
+/* O tamanho precisa ser declarado no próprio link e no <span> que ele
+   embrulha. Declarado só em .md-nav ele não chega ao item, que o tema
+   redefine — a regra existia e não valia nada. */
+.md-nav__link,
+.md-nav__link .md-ellipsis {
   font-size: 0.66rem;
 }
 
-.md-nav__title {
+.md-nav__title,
+.md-nav__title .md-ellipsis {
   font-size: 0.62rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;


### PR DESCRIPTION
A regra `.md-nav { font-size: 0.66rem }`, que entrou junto com a direção visual no #21, **nunca chegava aos itens do menu**. O tema redefine o tamanho abaixo dela na árvore, e o link continuava nos 16px padrão:

```
.md-nav        13,2px   ← a regra escrita
.md-nav__list  13,2px
.md-nav__item  16px     ← redefinido pelo tema
.md-nav__link  16px
```

Ou seja: o menu no ar está maior do que o pretendido, e a monoespaçada levou a culpa pelas quebras de linha que eu tinha reportado.

O tamanho passa a ser declarado no próprio link e no `<span>` que ele embrulha, que é onde ele pega. Mesmo tratamento para o título do menu.

### Medição

A/B na mesma largura de lateral (227px) e na mesma página, alternando só o tamanho:

| | itens que quebram | linhas no menu |
|---|---|---|
| regra morta (16px) | 113 | 332 |
| **regra valendo (13,2px)** | **89** | **290** |

### Isso não esgota o assunto

A causa maior das quebras é geométrica — 227px de largura contra títulos como "Como interpretar atalhos e comandos". Medi as alternativas antes de escrever isto:

| mudança | quebram | linhas |
|---|---|---|
| trocar mono por sans | 110 | 329 |
| trocar mono por Literata | 112 | 331 |
| lateral a 300px | 78 | 273 |
| lateral a 360px | 45 | 239 |
| lateral 300px + fonte 11px | 14 | 208 |

**Trocar a família não resolve** — quatro itens de diferença. Eu tinha afirmado o contrário sem testar. O que move o ponteiro depois deste PR é alargar a lateral, e isso é decisão de layout que vale discutir em separado.