### PR TITLE
Adiciona Google Analytics ao site

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -264,3 +264,7 @@ alternate_style = true
 
 [project.markdown_extensions.pymdownx.tasklist]
 custom_checkbox = true
+
+[project.extra.analytics]
+provider = "google"
+property = "G-PCSGHW9X3C"


### PR DESCRIPTION
## Summary
- Configura o Google Analytics (GA4) no site via `[project.extra.analytics]` no `zensical.toml`

## Test plan
- [x] Build local (`zensical build`) confirmando a injeção do script gtag.js com a property configurada