### PR TITLE
Corrige formatação e link quebrado na nota da página inicial

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,4 +27,4 @@ Este trabalho está em constante aprimoramento e é fruto da colaboração de vo
 [Veja como contribuir para o projeto](https://github.com/cassiobotaro/vimbook/blob/main/CONTRIBUTING.md)
 
 !!! note
-        Este livro é apenas a transcrição do [livro original](https://code.google.com/archive/p/vimbook) para [markdown](https://spec.commonmark.org/) e posteriormente utilizando [zensical](https://zensical.org/). Uma lista completa com os autores originais e aqueles que ajudaram na transcrição pode ser encontrada em: [https://github.com/cassiobotaro/vimbook/blob/main/AUTHORS](https://github.com/cassiobotaro/vimbook/blob/main/AUTHORS)
+    Este livro é apenas a transcrição do [livro original](https://web.archive.org/web/20120525202225/http://code.google.com/p/vimbook/) para [markdown](https://spec.commonmark.org/) e posteriormente utilizando [zensical](https://zensical.org/). Uma lista completa com os autores originais e aqueles que ajudaram na transcrição pode ser encontrada em: [AUTHORS](https://github.com/cassiobotaro/vimbook/blob/main/AUTHORS)


### PR DESCRIPTION
## Resumo
- Corrige a indentação do bloco `!!! note` (8 → 4 espaços), que fazia o Markdown renderizar o conteúdo como bloco de código em vez de parágrafo com links clicáveis
- Substitui o link morto do livro original (`code.google.com/archive/p/vimbook`, serviço desativado pelo Google) por um snapshot funcional no Wayback Machine
- Troca o texto do link para o AUTHORS, que exibia a URL crua, por "AUTHORS"

## Plano de teste
- [x] Build local (`zensical build`) confirmando que os links aparecem como `<a>` dentro de um `<p>`, e não dentro de `<pre><code>`