### PR TITLE
Usa vimbook.com.br como domínio principal do site

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -1,6 +1,6 @@
 [project]
 site_name = "Vimbook"
-site_url = "https://cassiobotaro.dev/vimbook/"
+site_url = "https://vimbook.com.br/"
 repo_name = "cassiobotaro/vimbook"
 repo_url = "https://github.com/cassiobotaro/vimbook"
 extra_css = ["stylesheets/_fontes.css", "stylesheets/vimbook.css"]


### PR DESCRIPTION
## Resumo
- `vimbook.com.br` agora está configurado como domínio custom do GitHub Pages para este repositório (DNS apontando para o GitHub, certificado HTTPS emitido e "Enforce HTTPS" habilitado)
- Atualiza `site_url` de `https://cassiobotaro.dev/vimbook/` para `https://vimbook.com.br/`, corrigindo as URLs canônicas e o sitemap gerados pelo build

## Plano de teste
- [x] `curl` direto no IP do GitHub Pages confirma HTTP 200 servido pelo GitHub em `https://vimbook.com.br/`
- [x] Build local (`zensical build`) confirmando que o `<link rel="canonical">` e o `sitemap.xml` usam o novo domínio