### PR TITLE
Ativa recursos do Zensical: tooltips, cabeçalho retrátil, busca destacada, edição no GitHub e consentimento de cookies

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -226,12 +226,16 @@ language = "pt"
 font = false
 favicon = "imgs/favicon.ico"
 features = [
+  "content.action.edit",
+  "content.footnote.tooltips",
   "content.tabs.link",
+  "header.autohide",
   "navigation.footer",
   "navigation.instant",
   "navigation.instant.progress",
   "navigation.top",
   "navigation.tracking",
+  "search.highlight",
   "toc.follow",
 ]
 
@@ -268,3 +272,11 @@ custom_checkbox = true
 [project.extra.analytics]
 provider = "google"
 property = "G-PCSGHW9X3C"
+
+[project.extra.consent]
+title = "Cookies"
+description = """
+Usamos cookies para reconhecer suas visitas e medir a audiência do site.
+Com o seu consentimento, você nos ajuda a melhorar o vimbook.
+"""
+actions = ["accept", "reject", "manage"]


### PR DESCRIPTION
## Resumo
- Ativa `content.footnote.tooltips`: notas de rodapé aparecem em tooltip ao passar o mouse, sem precisar rolar até o fim da página.
- Ativa `header.autohide`: o cabeçalho some ao rolar para baixo e volta ao rolar para cima, ganhando espaço de leitura.
- Ativa `search.highlight`: destaca o termo buscado na página de destino.
- Ativa `content.action.edit`: adiciona um link "editar esta página" usando o `repo_url` já configurado, para quem quiser propor correções via PR.
- Adiciona `[project.extra.consent]`: banner de consentimento de cookies, já que o Google Analytics configurado grava cookies próprios de sessão (`_ga`).

## Plano de teste
- [x] `zensical build` sem warnings
- [x] Testado manualmente em `zensical serve` (tooltips, cabeçalho retrátil, edição no GitHub, banner de cookies)