### PR TITLE
Corrige link de edição no GitHub

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -3,6 +3,7 @@ site_name = "Vimbook"
 site_url = "https://vimbook.com.br/"
 repo_name = "cassiobotaro/vimbook"
 repo_url = "https://github.com/cassiobotaro/vimbook"
+edit_uri = "edit/main/docs/"
 extra_css = ["stylesheets/_fontes.css", "stylesheets/vimbook.css"]
 extra_javascript = ["javascripts/navegacao.js", "javascripts/statusline.js"]
 


### PR DESCRIPTION
## Resumo
- O Zensical usa "master" como padrão para o `edit_uri` de repositórios no GitHub, mas a branch principal do vimbook é `main`, o que causava 404 ao clicar no ícone de edição das páginas
- Define `edit_uri` explicitamente apontando para `main`

## Como testar
- [ ] Acessar uma página do site e clicar no ícone de edição
- [ ] Confirmar que a URL leva para `github.com/cassiobotaro/vimbook/edit/main/docs/...` sem 404