### PR TITLE
Converte listas de comandos em tabelas e ativa cópia em blocos de código

### DIFF
--- a/docs/capitulo_1/ajuda_integrada.md
+++ b/docs/capitulo_1/ajuda_integrada.md
@@ -10,10 +10,11 @@ Obs: No Vim quase todos os comandos podem ser abreviados, no caso
 pode ser abreviado até o ponto em que este nome mais curto não coincida
 com o nome de algum outro comando existente. Para chamar a ajuda do Vim
 pressione `Esc` e em seguida:
-```
-:help .... versão longa, ou
-:h ....... versão abreviada
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:help` | versão longa, ou |
+| `:h` | versão abreviada |
 
 ou simplesmente `<F1>`.
 

--- a/docs/capitulo_1/entrando_em_modo_de_edicao.md
+++ b/docs/capitulo_1/entrando_em_modo_de_edicao.md
@@ -3,15 +3,16 @@ title: Entrando em modo de edição
 ---
 
 Estando no modo normal, digita-se:
-```
-a .... inicia inserção de texto após o caractere atual
-i .... inicia inserção de texto antes do caractere atual
-A .... inicia inserção de texto no final da linha
-I .... inicia inserção de texto no começo da linha
-o .... inicia inserção de texto na linha abaixo
-O .... inicia inserção de texto na linha acima
-gi ... inicia inserção no último ponto onde ocorreu inserção
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `a` | inicia inserção de texto após o caractere atual |
+| `i` | inicia inserção de texto antes do caractere atual |
+| `A` | inicia inserção de texto no final da linha |
+| `I` | inicia inserção de texto no começo da linha |
+| `o` | inicia inserção de texto na linha abaixo |
+| `O` | inicia inserção de texto na linha acima |
+| `gi` | inicia inserção no último ponto onde ocorreu inserção |
 
 Outra possibilidade é utilizar a tecla `<Insert>` para entrar no modo de
 inserção de texto antes do caractere atual, ou seja, o mesmo que a tecla

--- a/docs/capitulo_10/comandos_relativos_a_verificacao_ortografica.md
+++ b/docs/capitulo_10/comandos_relativos_a_verificacao_ortografica.md
@@ -10,10 +10,12 @@ apropriado realizar a verificação ortográfica do documento por inteiro.
 O Vim dispõe de comandos específicos para busca e movimentação em
 palavras grafadas incorretamente (desconhecidas) no escopo do documento,
 dentre eles:
-```
-]s ..... vai para a próxima palavra desconhecida
-[s ..... como o ]s, mas procura no sentido oposto
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `]s` | vai para a próxima palavra desconhecida |
+| `[s` | como o ]s, mas procura no sentido oposto |
+
 Ambos os comandos aceitam um prefixo numérico, que indica a quantidade
 de movimentações (buscas). Por exemplo, o comando 3]s vai
 para a *terceira* palavra desconhecida a partir da posição

--- a/docs/capitulo_11/criando_sessoes.md
+++ b/docs/capitulo_11/criando_sessoes.md
@@ -3,7 +3,8 @@ title: Criando sessões
 ---
 
 Sessões são criadas através do comando `:mksession`:
-```
-:mks[ession] sessao.vim .... cria a sessão e armazena-a em sessao.vim
-:mks[ession]! sessao.vim ... salva a sessão e sobrescreve-a em sessao.vim
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:mks[ession] sessao.vim` | cria a sessão e armazena-a em sessao.vim |
+| `:mks[ession]! sessao.vim` | salva a sessão e sobrescreve-a em sessao.vim |

--- a/docs/capitulo_12/criando_menus_para_um_modo_especifico.md
+++ b/docs/capitulo_12/criando_menus_para_um_modo_especifico.md
@@ -2,13 +2,13 @@
 title: Criando menus para um modo específico
 ---
 
-```
-:menu .... Normal, Visual e Operator-pending
-:nmenu ... Modo Normal
-:vmenu ... Modo Visual
-:omenu ... Operator-pending modo
-:menu! ... Insert e Comando
-:imenu ... Modo de inserção
-:cmenu ... Modo de comando
-:amenu ... Todos os modos
-```
+| Comando | Descrição |
+|---------|-----------|
+| `:menu` | Normal, Visual e Operator-pending |
+| `:nmenu` | Modo Normal |
+| `:vmenu` | Modo Visual |
+| `:omenu` | Operator-pending modo |
+| `:menu!` | Insert e Comando |
+| `:imenu` | Modo de inserção |
+| `:cmenu` | Modo de comando |
+| `:amenu` | Todos os modos |

--- a/docs/capitulo_12/efetivacao_das_alteracoes_no_vimrc.md
+++ b/docs/capitulo_12/efetivacao_das_alteracoes_no_vimrc.md
@@ -5,8 +5,9 @@ title: Efetivação das alterações no vimrc
 As alterações no *vimrc* só serão efetivadas na próxima vez
 que o Vim for aberto, a não ser que o recarregamento do arquivo de
 configuração seja instruído explicitamente:
-```
-:source ~/vimrc ....... se estiver no GNU/Linux
-:source ~/_vimrc ...... caso use o Windows
-:so arquivo ........... `so' é uma abreviação de `source'
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:source ~/vimrc` | se estiver no GNU/Linux |
+| `:source ~/_vimrc` | caso use o Windows |
+| `:so arquivo` | `so' é uma abreviação de `source' |

--- a/docs/capitulo_12/mapeamentos.md
+++ b/docs/capitulo_12/mapeamentos.md
@@ -122,19 +122,21 @@ No mapeamento acima estamos associando o atalho:
 ```
 … à ação desejada, fazer com que linhas em branco sucessivas sejam
 substituídas por uma só linha em branco, vejamos como funciona:
-```
-map ......... mapear
-,d .......... atalho que quermos
-<Esc> ....... se estive em modo de inserção sai
-: ........... em modo de comando
-% ........... em todo o arquivo
-s ........... substitua
-\n .......... quebra de linha
-{2,} ........ duas ou mais vezes
-\r .......... trocado por \r Enter
-g ........... globalmente
-<cr> ........ confirmação do comando
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `map` | mapear |
+| `,d` | atalho que quermos |
+| `<Esc>` | se estive em modo de inserção sai |
+| `:` | em modo de comando |
+| `%` | em todo o arquivo |
+| `s` | substitua |
+| `\n` | quebra de linha |
+| `{2,}` | duas ou mais vezes |
+| `\r` | trocado por \r Enter |
+| `g` | globalmente |
+| `<cr>` | confirmação do comando |
+
 As barras invertidas podem não ser usadas se o seu Vim estiver com a
 opção **magic** habilitada
 ```

--- a/docs/capitulo_12/outros_mapeamentos.md
+++ b/docs/capitulo_12/outros_mapeamentos.md
@@ -4,16 +4,18 @@ highlight RedundantWhitespace ctermbg=red guibg=red
 match RedundantWhitespace /\s\+$\| \+\ze\t/
 ```
 Explicando com detalhes
-```
-\s ..... espaço
-\+ ..... uma ou mais vezes
-$ ...... no final da linha
-\| ..... ou
-`` '' .. espaço (veja imagem acima)
-\+ ..... uma ou mais vezes
-\ze .... até o fim
-\t ..... tabulação
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `\s` | espaço |
+| `\+` | uma ou mais vezes |
+| `$` | no final da linha |
+| `\|` | ou |
+| ```` ''`` | espaço (veja imagem acima) |
+| `\+` | uma ou mais vezes |
+| `\ze` | até o fim |
+| `\t` | tabulação |
+
 Portanto a expressão regular acima localizará espaços ou tabulações no
 final de linha e destacará em vermelho.
 ```VimL

--- a/docs/capitulo_14/mova-se_rapidamente_no_texto.md
+++ b/docs/capitulo_14/mova-se_rapidamente_no_texto.md
@@ -7,9 +7,11 @@ mostra uma série de comandos para agilizar a navegação no texto.
 Memorizando estes comandos ganha-se tempo considerável, um exemplo
 simples em que o usuário está na linha 345 de um arquivo decide ver o
 conteúdo da linha 1 e em seguida voltar à linha 345:
-```
-gg ....... vai para a linha 1
-'' ....... retorna ao último ponto em que estava
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `gg` | vai para a linha 1 |
+| `''` | retorna ao último ponto em que estava |
+
 Fica claro portanto que a navegação rápida é um dos requisitos para
 edição efetiva de documentos.

--- a/docs/capitulo_14/use_quantificadores.md
+++ b/docs/capitulo_14/use_quantificadores.md
@@ -1,7 +1,8 @@
 Em modo normal você pode fazer
-```
-10j ..... desce 10 linhas
-5dd ..... apaga as próximas 5 linhas
-:50 ..... vai para a linha 50
-50gg .... vai para a linha 50
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `10j` | desce 10 linhas |
+| `5dd` | apaga as próximas 5 linhas |
+| `:50` | vai para a linha 50 |
+| `50gg` | vai para a linha 50 |

--- a/docs/capitulo_15/o_plugin_ctags.md
+++ b/docs/capitulo_15/o_plugin_ctags.md
@@ -37,7 +37,7 @@ O plugin de *Ctags* para o Vim está neste
 [link](http://vim.sourceforge.net/scripts/script.php?script_id=12),
 e para instalá-lo basta copiá-lo para a pasta apropriada:
 
-```
- ~/vimfiles/plugin .......... no windows
- ~/.vim/plugin .............. no Gnu/Linux
-```
+| Comando | Descrição |
+|---------|-----------|
+| `~/vimfiles/plugin` | no windows |
+| `~/.vim/plugin` | no Gnu/Linux |

--- a/docs/capitulo_15/o_plugin_easy_grep.md
+++ b/docs/capitulo_15/o_plugin_easy_grep.md
@@ -14,20 +14,20 @@ grep [opções] "padrão" /caminho
 
 Mas no caso do plugin *EasyGrep* fica assim:
 
-```
-:Grep foo  ........ procura pela palavra 'foo'
-:GrepOptions ...... exibe as opções de uso do plugin
-```
+| Comando | Descrição |
+|---------|-----------|
+| `:Grep foo` | procura pela palavra 'foo' |
+| `:GrepOptions` | exibe as opções de uso do plugin |
 
 O plugin pode ser obtido no seguinte
 [link](http://www.vim.org/scripts/script.php?script_id=2438#0.9).
 Já sua instalação é simples, basta copiar o arquivo obtido no link acima
 para a pasta:
 
-```
-~/.vim/plugin .......... no caso do linux
-~/vimfiles/plugin ...... no caso do windows
-```
+| Comando | Descrição |
+|---------|-----------|
+| `~/.vim/plugin` | no caso do linux |
+| `~/vimfiles/plugin` | no caso do windows |
 
 Um vídeo de exemplo (na verdade uma animação gif) pode ser visto
 [aqui](http://downloads.veryspeedy.net/vim/EasyGrep.gif).

--- a/docs/capitulo_15/o_plugin_project.md
+++ b/docs/capitulo_15/o_plugin_project.md
@@ -9,11 +9,11 @@ Para programadores é uma funcionalidade extremamente necessária.
 Costuma-se trabalhar com vários arquivos da mesma família ("extensão"),
 e ao clicar em um dos arquivos do projeto o mesmo é aberto instantaneamente.
 
-```
-:Project ......... abre uma janela lateral para o projeto
-\C ............... inicia a criação de um projeto (recursivamente)
-\c ............... inicia a criação de um projeto na pasta local
-```
+| Comando | Descrição |
+|---------|-----------|
+| `:Project` | abre uma janela lateral para o projeto |
+| `\C` | inicia a criação de um projeto (recursivamente) |
+| `\c` | inicia a criação de um projeto na pasta local |
 
 Após digitar o atalho de criação do projeto aparecerá uma janela
 para designar um nome para o mesmo, em seguida digita-se o caminho para

--- a/docs/capitulo_15/o_plugin_search_complete.md
+++ b/docs/capitulo_15/o_plugin_search_complete.md
@@ -19,10 +19,10 @@ Pode-se obter o plugin *SearchComplete* no seguinte
 [link](http://www.vim.org/scripts/script.php?script_id=474),
 e para instalá-lo basta copiá-lo para a pasta apropriada:
 
-```
-~/vimfiles/plugin .......... no windows
-~/.vim/plugin .............. no Gnu/Linux
-```
+| Comando | Descrição |
+|---------|-----------|
+| `~/vimfiles/plugin` | no windows |
+| `~/.vim/plugin` | no Gnu/Linux |
 
 Há outro plugin similar chamado `CmdlineComplete` disponível
 [neste link](http://www.vim.org/scripts/script.php?script_id=2222).

--- a/docs/capitulo_2/abrindo_o_ultimo_arquivo_rapidamente.md
+++ b/docs/capitulo_2/abrindo_o_ultimo_arquivo_rapidamente.md
@@ -3,11 +3,13 @@ title: Abrindo o último arquivo rapidamente
 ---
 
 O Vim guarda um registrador para cada arquivo editado veja mais no capítulo [Registradores](../capitulo_5/registradores.md).
-```
-'0 ........ abre o último arquivo editado
-'1 ........ abre o penúltimo arquivo editado
-Ctrl-6 .... abre o arquivo alternativo (booleano)
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `'0` | abre o último arquivo editado |
+| `'1` | abre o penúltimo arquivo editado |
+| `Ctrl-6` | abre o arquivo alternativo (booleano) |
+
 Bom, já que abrimos o nosso último arquivo editado com o comando:
 ```
 '0

--- a/docs/capitulo_2/comparando_arquivos_com_vimdiff.md
+++ b/docs/capitulo_2/comparando_arquivos_com_vimdiff.md
@@ -5,11 +5,13 @@ title: Comparando arquivos com o vimdiff
 O vim possui um modo para checagem de diferenças entre arquivos, é
 bastante útil especialmente para programadores, para saber quais são as
 diferenças entre dois arquivos faz-se:
-```
-diff arquivo1.txt arquivo2.txt .. exibe as diferenças
-]c ................................. mostra próxima diferença
-vim -d ............................. outro modo de abrir o vimdiff mode
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `diff arquivo1.txt arquivo2.txt` | exibe as diferenças |
+| `]c` | mostra próxima diferença |
+| `vim -d` | outro modo de abrir o vimdiff mode |
+
 Para usuários do GNU/Linux é possível ainda checar diferenças
 remotamente assim:
 ```

--- a/docs/capitulo_2/convertendo_para_maiusculas.md
+++ b/docs/capitulo_2/convertendo_para_maiusculas.md
@@ -2,10 +2,10 @@
 title: Convertendo para maiúsculas
 ---
 
-```
-gUU ....... converte a linha para maiúsculo
-guu ....... converte a linha para minúsculo
-gUiw ...... converte a palavra atual para maiúsculo
-~ ......... altera o case do caractere atual
-```
+| Comando | Descrição |
+|---------|-----------|
+| `gUU` | converte a linha para maiúsculo |
+| `guu` | converte a linha para minúsculo |
+| `gUiw` | converte a palavra atual para maiúsculo |
+| `~` | altera o case do caractere atual |
 

--- a/docs/capitulo_2/copiar_colar_deletar.md
+++ b/docs/capitulo_2/copiar_colar_deletar.md
@@ -4,55 +4,63 @@ title: Copiar, Colar e Deletar
 
 No modo normal, o ato de deletar ou eliminar o texto está associado à
 letra `d`. No modo de inserção as teclas usuais também funcionam.
-```
-dd .... deleta linha atual
-D ..... deleta restante da linha
-d$ .... deleta do ponto atual até o final da linha
-d^ .... deleta do cursor ao primeiro caractere não-nulo da linha
-d0 .... deleta do cursor ao início da linha
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `dd` | deleta linha atual |
+| `D` | deleta restante da linha |
+| `d$` | deleta do ponto atual até o final da linha |
+| `d^` | deleta do cursor ao primeiro caractere não-nulo da linha |
+| `d0` | deleta do cursor ao início da linha |
+
 Pode-se combinar o comando de deleção `d` com o comando de movimento
 (considere o modo normal) para apagar até a próxima vírgula use:
 `df,`.
 
 Copiar está associado à letra `y`.
-```
-yy .... copia a linha atual
-Y ..... copia a linha atual
-ye .... copia do cursor ao fim da palavra
-yb .... copia do começo da palavra ao cursor
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `yy` | copia a linha atual |
+| `Y` | copia a linha atual |
+| `ye` | copia do cursor ao fim da palavra |
+| `yb` | copia do começo da palavra ao cursor |
+
 O que foi deletado ou copiado pode ser colado:
-```
-p .... cola o que foi copiado ou deletado abaixo
-P .... cola o que foi copiado ou deletado acima
-[p ... cola o que foi copiado ou deletado antes do cursor
-]p ... cola o que foi copiado ou deletado após o cursor
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `p` | cola o que foi copiado ou deletado abaixo |
+| `P` | cola o que foi copiado ou deletado acima |
+| `[p` | cola o que foi copiado ou deletado antes do cursor |
+| `]p` | cola o que foi copiado ou deletado após o cursor |
+
 ### Deletando uma parte do texto
 
 O comando `d` remove o conteúdo para a memória.
-```
-x .... apaga o caractere sob o cursor
-xp ... troca letras de lugar
-ddp .. troca linhas de lugar
-d5x .. apaga os próximos 5 caracteres
-dd  .. apaga a linha atual
-5dd .. apaga 5 linhas (também pode ser: d5d)
-d5G .. apaga até a linha 5
-dw  .. apaga uma palavra
-5dw .. apaga 5 palavras (também pode ser: d5w)
-dl  .. apaga uma letra (sinônimo: x)
-5dl .. apaga 5 letras (também pode ser: d5l ou 5x)
-d0  .. apaga até o início da linha
-d^  .. apaga até o primeiro caractere da linha
-d$  .. apaga até o final da linha (sinônimo: D)
-dgg .. apaga até o início do arquivo
-dG  .. apaga até o final do arquivo
-D .... apaga o resto da linha
-d% ... deleta até o próximo (,[,{
-da" .. deleta aspas com conteúdo
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `x` | apaga o caractere sob o cursor |
+| `xp` | troca letras de lugar |
+| `ddp` | troca linhas de lugar |
+| `d5x` | apaga os próximos 5 caracteres |
+| `dd` | apaga a linha atual |
+| `5dd` | apaga 5 linhas (também pode ser: d5d) |
+| `d5G` | apaga até a linha 5 |
+| `dw` | apaga uma palavra |
+| `5dw` | apaga 5 palavras (também pode ser: d5w) |
+| `dl` | apaga uma letra (sinônimo: x) |
+| `5dl` | apaga 5 letras (também pode ser: d5l ou 5x) |
+| `d0` | apaga até o início da linha |
+| `d^` | apaga até o primeiro caractere da linha |
+| `d$` | apaga até o final da linha (sinônimo: D) |
+| `dgg` | apaga até o início do arquivo |
+| `dG` | apaga até o final do arquivo |
+| `D` | apaga o resto da linha |
+| `d%` | deleta até o próximo (,[,{ |
+| `da"` | deleta aspas com conteúdo |
+
 Depois do texto ter sido colocado na memória, digite `p`
 para ‘inserir’ o texto em uma outra posição. Outros comandos:
 ```
@@ -65,12 +73,13 @@ d/casa/+1 - deleta até a linha após a palavra casa
 Trocando a letra `d` nos comandos acima por
 `c` de *change* (mudanças) ao invés de deletar
 será feita uma mudança de conteúdo. Por exemplo:
-```
-ciw .............. modifica uma palavra
-cip .............. modifica um parágrafo
-cis .............. modifica uma sentença
-C ................ modifica até o final da linha
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `ciw` | modifica uma palavra |
+| `cip` | modifica um parágrafo |
+| `cis` | modifica uma sentença |
+| `C` | modifica até o final da linha |
 
 ### Copiando sem deletar
 
@@ -79,43 +88,51 @@ parte do texto para a memória sem deletar. Existe uma semelhança muito
 grande entre os comandos `y` e os comandos
 `d`, um ativa a ‘cópia’ e outro a ‘exclusão’ de conteúdo,
 suportando ambos quantificadores:
-```
-yy  .... copia a linha atual (sinônimo: Y)
-5yy .... copia 5 linhas (também pode ser: y5y ou 5Y)
-y/pat .. copia até `pat'
-yw  .... copia uma palavra
-5yw .... copia 5 palavras (também pode ser: y5w)
-yl  .... copia uma letra
-5yl .... copia 5 letras (também pode ser: y5l)
-y^  .... copia da posição atual até o início da linha(sinônimo: y0)
-y$  .... copia da posição atual até o final da linha
-ygg .... copia da posição atual até o início do arquivo
-yG  .... copia da posição atual até o final do arquivo
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `yy` | copia a linha atual (sinônimo: Y) |
+| `5yy` | copia 5 linhas (também pode ser: y5y ou 5Y) |
+| `y/pat` | copia até `pat' |
+| `yw` | copia uma palavra |
+| `5yw` | copia 5 palavras (também pode ser: y5w) |
+| `yl` | copia uma letra |
+| `5yl` | copia 5 letras (também pode ser: y5l) |
+| `y^` | copia da posição atual até o início da linha(sinônimo: y0) |
+| `y$` | copia da posição atual até o final da linha |
+| `ygg` | copia da posição atual até o início do arquivo |
+| `yG` | copia da posição atual até o final do arquivo |
+
 Digite `P` (p maiúsculo) para colar o texto recém copiado
 na posição onde encontra-se o cursor, ou `p` para colar o
 texto na posição imediatamente após o cursor.
-```
-yi" .... copia trecho entre aspas (atual - inner)
-vip .... seleção visual para parágrafo atual `inner paragraph'
-yip .... copia o parágrafo atual
-yit .... copia a tag atual `inner tag' útil para arquivos HTML, XML, etc.
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `yi"` | copia trecho entre aspas (atual - inner) |
+| `vip` | seleção visual para parágrafo atual `inner paragraph' |
+| `yip` | copia o parágrafo atual |
+| `yit` | copia a tag atual `inner tag' útil para arquivos HTML, XML, etc. |
+
 ### Usando a área de transferência `Clipboard`
 
 Exemplos para o modo visual:
-```
-Ctrl-insert .... copia área selecionada
-Shift-insert ... cola o que está no clipboard
-Ctrl-del ....... recorta para o clipboard
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `Ctrl-insert` | copia área selecionada |
+| `Shift-insert` | cola o que está no clipboard |
+| `Ctrl-del` | recorta para o clipboard |
+
 Caso obtenhamos erro ao colar textos da área de transferência usando os
 comandos acima citados podemos usar outra alternativa. Os comandos
 abaixo preservam a indentação[^1].
-```
-"+p ............ cola preservando indentação
-"+y ............ copia área selecionada
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `"+p` | cola preservando indentação |
+| `"+y` | copia área selecionada |
+
 Para evitar erros ao colar usando `Shift-insert` use este
 comando `:set paste`.
 

--- a/docs/capitulo_2/desfazendo.md
+++ b/docs/capitulo_2/desfazendo.md
@@ -1,9 +1,11 @@
 Se você cometer um erro, não se preocupe! Use o comando `u`:
-```
-u ............ desfazer
-U ............ desfaz mudanças na última linha editada
-Ctrl-r  ...... refazer
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `u` | desfazer |
+| `U` | desfaz mudanças na última linha editada |
+| `Ctrl-r` | refazer |
+
 ### Undo tree
 
 Um novo recurso muito interessante que foi adicionado ao Vim a partir da

--- a/docs/capitulo_2/edicao_avancada_de_linhas.md
+++ b/docs/capitulo_2/edicao_avancada_de_linhas.md
@@ -21,13 +21,15 @@ fim (linha 10). Isto pode ser feito assim:
 :5,$ normal 0wd3w
 ```
 Explicando o comando acima:
-```
-:5,$ .... indica o intervalo que é da linha 5 até o fim '$'
-normal .. executa em modo normal
-0 ....... move o cursor para o começo da linha
-w ....... pula uma palavra
-d3w ..... apaga 3 palavras 'w'
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:5,$` | indica o intervalo que é da linha 5 até o fim '$' |
+| `normal` | executa em modo normal |
+| `0` | move o cursor para o começo da linha |
+| `w` | pula uma palavra |
+| `d3w` | apaga 3 palavras 'w' |
+
 Obs: É claro que um comando de substituição simples, como:
 ```
 :5,$s/é um texto//g
@@ -43,18 +45,20 @@ inserção). Por exemplo, suponha agora que deseja-se mudar a frase
 :5,$ normal 02winão ^[$ciwvelho
 ```
 Decompondo o comando acima temos:
-```
-:5,$ .... indica o intervalo que é da linha 5 até o fim '$'
-normal .. executa em modo normal
-0 ....... move o cursor para o começo da linha
-2w ...... pula duas palavras (vai para a palavra "é")
-i ....... entra no modo de inserção
-não  .... insere a palavra "não" seguida de espaço " "
-^[ ...... sai do modo de inserção (através de Ctrl-v seguido de Esc)
-$ ....... vai para o fim da linha
-ciw ..... apaga a última palavra ("novo") e entra em modo de inserção
-velho ... insere a palavra "velho" no lugar de "novo"
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:5,$` | indica o intervalo que é da linha 5 até o fim '$' |
+| `normal` | executa em modo normal |
+| `0` | move o cursor para o começo da linha |
+| `2w` | pula duas palavras (vai para a palavra "é") |
+| `i` | entra no modo de inserção |
+| `não` | insere a palavra "não" seguida de espaço " " |
+| `^[` | sai do modo de inserção (através de Ctrl-v seguido de Esc) |
+| `$` | vai para o fim da linha |
+| `ciw` | apaga a última palavra ("novo") e entra em modo de inserção |
+| `velho` | insere a palavra "velho" no lugar de "novo" |
+
 A combinação `Ctrl-v` é utilizada para inserir caracteres de controle na
 sua forma literal, prevenindo-se assim a interpretação destes neste
 exato momento.

--- a/docs/capitulo_2/editando_em_modo_comando.md
+++ b/docs/capitulo_2/editando_em_modo_comando.md
@@ -31,11 +31,13 @@ Podemos inverter a lógica do comando global `g`:
 ```
 Não delete as linhas contendo padrão, ou seja, delete tudo menos as
 linhas contendo a palavra ‘padrão’.
-```
-:v/padrão/d ........ apaga linhas que não contenham "padrão"
-:v/\S/d ............ apaga linhas vazias
-\S ................. significa "string"
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:v/padrão/d` | apaga linhas que não contenham "padrão" |
+| `:v/\S/d` | apaga linhas vazias |
+| `\S` | significa "string" |
+
 A opção acima equivale a `:g!/padrão/d`. Para ler mais sobre o comando
 “global” utilizado nesta seção veja o capítulo [O comando global "g"](../capitulo_6/o_comando_global_g.md).
 ```

--- a/docs/capitulo_2/incrementando_numeros_em_modo_normal.md
+++ b/docs/capitulo_2/incrementando_numeros_em_modo_normal.md
@@ -3,7 +3,8 @@ title: Incrementando números em modo normal
 ---
 
 Posicione o cursor sobre um número e pressione:
-```
-Ctrl-a ..... incrementa o número
-Ctrl-x ..... decrementa o número
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `Ctrl-a` | incrementa o número |
+| `Ctrl-x` | decrementa o número |

--- a/docs/capitulo_2/lendo_um_arquivo_para_a_linha_atual.md
+++ b/docs/capitulo_2/lendo_um_arquivo_para_a_linha_atual.md
@@ -1,5 +1,6 @@
 Se desejamos inserir na linha atual um arquivo qualquer fazemos:
-```
-:r /caminho/para/arquivo.txt .. insere o arquivo na linha atual
-:0r arquivo ................... insere o arquivo na primeira linha
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:r /caminho/para/arquivo.txt` | insere o arquivo na linha atual |
+| `:0r arquivo` | insere o arquivo na primeira linha |

--- a/docs/capitulo_2/lista_de_alteracoes.md
+++ b/docs/capitulo_2/lista_de_alteracoes.md
@@ -4,8 +4,9 @@ title: Lista de alterações
 
 O Vim mantém uma lista de alterações, veremos agora como usar este
 recurso.
-```
-g, ................. avança na lista de alterações
-g; ................. recua na lista de alterações
-:changes ........... visualiza a lista de alterações
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `g,` | avança na lista de alterações |
+| `g;` | recua na lista de alterações |
+| `:changes` | visualiza a lista de alterações |

--- a/docs/capitulo_2/movendo_um_trecho_de_forma_inusitada.md
+++ b/docs/capitulo_2/movendo_um_trecho_de_forma_inusitada.md
@@ -1,7 +1,7 @@
-```
-:20,30m 0 ..... move da linha `20` até `30` para o começo
-:20,/pat/m 5 .. move da linha `20` até `pat` para a linha 5
-:m-5 .......... move a linha atual 5 posições acima
-:m0 ........... move a linha atual para o começo
-:m$ ........... move para o final do documento
-```
+| Comando | Descrição |
+|---------|-----------|
+| `:20,30m 0` | move da linha `20` até `30` para o começo |
+| `:20,/pat/m 5` | move da linha `20` até `pat` para a linha 5 |
+| `:m-5` | move a linha atual 5 posições acima |
+| `:m0` | move a linha atual para o começo |
+| `:m$` | move para o final do documento |

--- a/docs/capitulo_2/ordenando.md
+++ b/docs/capitulo_2/ordenando.md
@@ -1,10 +1,12 @@
 O Vim, versão 7 ou superior, passa a ter um comando de ordenação que
 também permite a retirada de linhas duplicadas, tal como foi
 apresentado.
-```
-:sort u ... ordena e retira linhas duplicadas
-:sort n ... ordena numericamente
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:sort u` | ordena e retira linhas duplicadas |
+| `:sort n` | ordena numericamente |
+
 Obs: a ordenação numérica é diferente da ordenação alfabética se em um
 trecho contendo algo como:
 ```

--- a/docs/capitulo_2/substituindo_tabulacoes_por_espacos.md
+++ b/docs/capitulo_2/substituindo_tabulacoes_por_espacos.md
@@ -18,16 +18,18 @@ onde
 <Ctrl-i>...... insere uma tabulação
 ```
 Explicando:
-```
-: ............ comando
-% ............ em todo arquivo
-s ............ substitua
-/ ............ padrão de busca
-\s ........... localiza espaço
-\{4,} ........ quatro vezes
-/ ............ inicio da substituição
-<Ctrl-i> ..... pressione Ctrl-i para inserir <Tab>
-/ ............ fim da substituição
-g ............ global
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:` | comando |
+| `%` | em todo arquivo |
+| `s` | substitua |
+| `/` | padrão de busca |
+| `\s` | localiza espaço |
+| `\{4,}` | quatro vezes |
+| `/` | inicio da substituição |
+| `<Ctrl-i>` | pressione Ctrl-i para inserir `<Tab>` |
+| `/` | fim da substituição |
+| `g` | global |
+
 [^1]: Em códigos Python por exemplo não se pode misturar espaços e tabulações

--- a/docs/capitulo_3/movendo-se_no_documento.md
+++ b/docs/capitulo_3/movendo-se_no_documento.md
@@ -41,11 +41,11 @@ para a movimentação.
 
 Para ir para linhas específicas ‘em modo normal’ digite:
 
-```
-:n<Enter>  ..... vai para linha `n'
-ngg ............ vai para linha `n'
-nG ............. vai para linha `n'
-```
+| Comando | Descrição |
+|---------|-----------|
+| `:n<Enter>` | vai para linha `n' |
+| `ngg` | vai para linha `n' |
+| `nG` | vai para linha `n' |
 
 onde `n` corresponde ao número da linha. Para retornar ao modo normal
 pressione `<Esc>` ou use `Ctrl-[` (`^[`).
@@ -107,22 +107,22 @@ são consideradas em separado, portanto se você usar, em modo normal
 entanto se usar `W` em maiúsculo (como visto) ele pulará a
 “palavra-inteira” :)
 
-```
-E .... pula para o final de palavras com hifen
-B .... pula palavras com hifen (retrocede)
-W .... pula palavras hifenizadas (começo)
-```
+| Comando | Descrição |
+|---------|-----------|
+| `E` | pula para o final de palavras com hifen |
+| `B` | pula palavras com hifen (retrocede) |
+| `W` | pula palavras hifenizadas (começo) |
 
 Podemos pular sentenças:
 
-```
-) .... pula uma sentença para frente
-( .... pula uma sentença para trás
-} .... pula um parágrafo para frente
-{ .... pula um parágrafo para trás
-y) ... copia uma sentença para frente
-d} ... deleta um parágrafo para frente
-```
+| Comando | Descrição |
+|---------|-----------|
+| `)` | pula uma sentença para frente |
+| `(` | pula uma sentença para trás |
+| `}` | pula um parágrafo para frente |
+| `{` | pula um parágrafo para trás |
+| `y)` | copia uma sentença para frente |
+| `d}` | deleta um parágrafo para frente |
 
 Caso tenha uma estrutura como abaixo:
 
@@ -202,22 +202,22 @@ outro detalhe para voltar ao último ponto em que você estava
 
 A maioria dos comandos do Vim pode ser precedida por um quantificador:
 
-```
-5j ..... desce 5 linhas
-d5j .... deleta as próximas 5 linhas
-k ...... em modo normal sobe uma linha
-5k ..... sobe 5 linhas
-y5k .... copia 5 linhas (para cima)
-w ...... pula uma palavra para frente
-5w ..... pula 5 palavras
-d5w .... deleta 5 palavras
-b ...... retrocede uma palavra
-5b ..... retrocede 5 palavras
-fx ..... posiciona o cursor em "x"
-dfx .... deleta até o próximo "x"
-dgg .... deleta da linha atual até o começo do arquivo
-dG ..... deleta até o final do arquivo
-yG ..... copia até o final do arquivo
-yfx .... copia até o próximo "x"
-y5j .... copia 5 linhas
-```
+| Comando | Descrição |
+|---------|-----------|
+| `5j` | desce 5 linhas |
+| `d5j` | deleta as próximas 5 linhas |
+| `k` | em modo normal sobe uma linha |
+| `5k` | sobe 5 linhas |
+| `y5k` | copia 5 linhas (para cima) |
+| `w` | pula uma palavra para frente |
+| `5w` | pula 5 palavras |
+| `d5w` | deleta 5 palavras |
+| `b` | retrocede uma palavra |
+| `5b` | retrocede 5 palavras |
+| `fx` | posiciona o cursor em "x" |
+| `dfx` | deleta até o próximo "x" |
+| `dgg` | deleta da linha atual até o começo do arquivo |
+| `dG` | deleta até o final do arquivo |
+| `yG` | copia até o final do arquivo |
+| `yfx` | copia até o próximo "x" |
+| `y5j` | copia 5 linhas |

--- a/docs/capitulo_3/paginando.md
+++ b/docs/capitulo_3/paginando.md
@@ -18,10 +18,10 @@ gd ....... pula para a definição de uma variável
 
 Observação: lembre-se
 
-```
-^ .... equivale a Ctrl
-^I ... equivale a Ctrl-I
-```
+| Comando | Descrição |
+|---------|-----------|
+| `^` | equivale a Ctrl |
+| `^I` | equivale a Ctrl-I |
 
 É possível abrir vários arquivos tipo `vim *.txt`. Editar algum arquivo,
 salvar e ir para o próximo arquivo com o comando à seguir:

--- a/docs/capitulo_3/usando_marcas.md
+++ b/docs/capitulo_3/usando_marcas.md
@@ -44,11 +44,11 @@ Isto fará o Vim dar um salto até a marca ‘A’ mesmo que
 esteja em outro arquivo, mesmo que você tenha acabado de fecha-lo. Para
 abrir e editar vários arquivos do Vim fazemos:
 
-```
-vim *.txt ......... abre todos os arquivos 'txt'
-:bn ............... vai para o próximo da lista
-:bp ............... volta para o arquivo anterior
-:ls ............... lista todos os arquivos abertos
-:wn ............... salva e vai para o próximo
-:wp ............... salva e vai para o anterior
-```
+| Comando | Descrição |
+|---------|-----------|
+| `vim *.txt` | abre todos os arquivos 'txt' |
+| `:bn` | vai para o próximo da lista |
+| `:bp` | volta para o arquivo anterior |
+| `:ls` | lista todos os arquivos abertos |
+| `:wn` | salva e vai para o próximo |
+| `:wp` | salva e vai para o anterior |

--- a/docs/capitulo_4/criando_dobras_usando_o_modo_visual.md
+++ b/docs/capitulo_4/criando_dobras_usando_o_modo_visual.md
@@ -1,10 +1,12 @@
 Para iniciar a seleção visual
-```
-Esc ........ vai para o modo normal
-shift-v .... inicia seleção visual
-j .......... aumenta a seleção visual (desce)
-zf ......... cria a dobra na seleção ativa
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `Esc` | vai para o modo normal |
+| `shift-v` | inicia seleção visual |
+| `j` | aumenta a seleção visual (desce) |
+| `zf` | cria a dobra na seleção ativa |
+
 Um modo inusitado de se criar dobras é:
 ```
 Shift-v ..... inicia seleção visual

--- a/docs/capitulo_4/folders.md
+++ b/docs/capitulo_4/folders.md
@@ -16,9 +16,10 @@ com o comando abaixo:
 zf10j
 ```
 Você pode ainda criar uma seleção visual
-```
-Shift-v ............ seleção por linha
-j .................. desce linha
-zf ................. cria o folder
-zo ................. abre o folder
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `Shift-v` | seleção por linha |
+| `j` | desce linha |
+| `zf` | cria o folder |
+| `zo` | abre o folder |

--- a/docs/capitulo_5/como_colocar_um_pedaco_de_texto_em_um_registrador.md
+++ b/docs/capitulo_5/como_colocar_um_pedaco_de_texto_em_um_registrador.md
@@ -2,10 +2,11 @@
 title: Como colocar um pedaço de texto em um registrador?
 ---
 
-```
- <Esc> ...... vai para o modo normal
- "a10j ...... coloca no registrador `a' as próximas 10 linhas `10j'
-```
+| Comando | Descrição |
+|---------|-----------|
+| `<Esc>` | vai para o modo normal |
+| `"a10j` | coloca no registrador `a' as próximas 10 linhas `10j' |
+
 Pode-se fazer:
 ```
 <Esc> ...... para ter certeza que está em modo normal

--- a/docs/capitulo_5/como_definir_um_registrador_no_vimrc.md
+++ b/docs/capitulo_5/como_definir_um_registrador_no_vimrc.md
@@ -6,10 +6,12 @@ Se você não sabe ainda como editar preferências no Vim leia antes o
 capítulo [Como editar preferências no Vim](../capitulo_12/como_editar_preferencias_no_vim.md).
 
 Você pode criar uma variável no vimrc assim:
-```
-let var="foo" ...... define foo para var
-echo var ........... mostra o valor de var
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `let var="foo"` | define foo para var |
+| `echo var` | mostra o valor de var |
+
 Pode também dizer ao Vim algo como...
 ```
 :let @d=strftime("c")<Enter>

--- a/docs/capitulo_5/como_selecionar_blocos_verticais_de_texto.md
+++ b/docs/capitulo_5/como_selecionar_blocos_verticais_de_texto.md
@@ -13,8 +13,9 @@ em um registrador
 "ayip
 ```
 O comando acima quer dizer
-```
-para o registrador `a' ........  "a
-copie ......................  `y`
-o parágrafo atual ..........  `inner paragraph`
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| ``para o registrador `a'`` | "a |
+| `copie` | `y` |
+| `o parágrafo atual` | `inner paragraph` |

--- a/docs/capitulo_5/manipulando_registradores.md
+++ b/docs/capitulo_5/manipulando_registradores.md
@@ -12,13 +12,15 @@
 :reg         ... mostra o conteúdo de todos os registradores
 ```
 Em modo de inserção
-```
-<C-R>-   ....... Insere o registrador de pequenas deleções
-<C-R>[0-9a-z] .. Insere registradores 0-9 e a-z
-<C-R>%        .. Insere o nome do arquivo
-<C-R>=somevar .. Insere o conteúdo de uma variável
-<C-R><C-A> ..... Insere `Big-Words' veja seção 2.1
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `<C-R>-` | Insere o registrador de pequenas deleções |
+| `<C-R>[0-9a-z]` | Insere registradores 0-9 e a-z |
+| `<C-R>%` | Insere o nome do arquivo |
+| `<C-R>=somevar` | Insere o conteúdo de uma variável |
+| `<C-R><C-A>` | Insere `Big-Words' veja seção 2.1 |
+
 Um exemplo: pré-carregando o nome do arquivo no registrador `n`.
 
 coloque em seu `~/.vimrc`

--- a/docs/capitulo_5/o_registrador_sem_nome.md
+++ b/docs/capitulo_5/o_registrador_sem_nome.md
@@ -3,13 +3,15 @@ title: O registrador sem nome ""
 ---
 
 Armazena o conteúdo de ações como:
-```
-d ....... deleção
-s ....... substituição
-c ....... modificação (change)
-x ....... apaga um caractere
-yy ...... copia uma linha inteira
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `d` | deleção |
+| `s` | substituição |
+| `c` | modificação (change) |
+| `x` | apaga um caractere |
+| `yy` | copia uma linha inteira |
+
 Para acessar o conteúdo deste registrador basta usar as letras
 "p" ou "P" que na verdade são comandos para
 colar abaixo da linha atual e acima da linha atual (em modo normal).

--- a/docs/capitulo_5/registradores_nomeados_de_a_ate_z_ou_a_ate_z.md
+++ b/docs/capitulo_5/registradores_nomeados_de_a_ate_z_ou_a_ate_z.md
@@ -14,9 +14,10 @@ este comando:
 ```
 Neste caso a linha corrente é apagada 'dd' e adicionada ao
 final do registrador "a".
-```
-"ayip .. copia o parágrafo atual para o registrador "a"
-"a ..... registrador a
-y ...... yank (copia)
-ip ..... inner paragraph (este parágrafo)
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `"ayip` | copia o parágrafo atual para o registrador "a" |
+| `"a` | registrador a |
+| `y` | yank (copia) |
+| `ip` | inner paragraph (este parágrafo) |

--- a/docs/capitulo_5/registradores_somente_leitura.md
+++ b/docs/capitulo_5/registradores_somente_leitura.md
@@ -4,20 +4,24 @@ title: Registradores somente leitura ":.%#"
 
 Registradores somente leitura ": . % \#"
 ------------------------------------
-```
-": ..... armazena o último comando
-". ..... armazena uma cópia do último texto inserido
-"% ..... contém o nome do arquivo corrente
-"# ..... contém o nome do arquivo alternativo
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `":` | armazena o último comando |
+| `".` | armazena uma cópia do último texto inserido |
+| `"%` | contém o nome do arquivo corrente |
+| `"#` | contém o nome do arquivo alternativo |
+
 Uma forma prática de usar registradores em modo de inserção é usando:
 `Ctrl-r`
-```
-Ctrl-r % .... insere o nome do arquivo atual
-Ctrl-r : .... insere o último comando digitado
-Ctrl-r / .... insere a última busca efetuada
-Ctrl-r a .... insere o registrador `a'
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `Ctrl-r %` | insere o nome do arquivo atual |
+| `Ctrl-r :` | insere o último comando digitado |
+| `Ctrl-r /` | insere a última busca efetuada |
+| `Ctrl-r a` | insere o registrador `a' |
+
 Em modo de inserção pode-se repetir a última inserção de texto
 simplesmente pressionando:
 ```

--- a/docs/capitulo_6/corrigindo_a_indentacao_de_codigos.md
+++ b/docs/capitulo_6/corrigindo_a_indentacao_de_codigos.md
@@ -3,8 +3,9 @@ title: Corrigindo a indentação de códigos
 ---
 
 Selecione o bloco de código, por exemplo
-```
-vip  ..... visual ``inner paragraph'' (selecione este parágrafo)
-=  ....... corrige a indentação do bloco de texto selecionado
-ggVG= .... corrige a identação do arquivo inteiro
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `vip` | visual ``inner paragraph'' (selecione este parágrafo) |
+| `=` | corrige a indentação do bloco de texto selecionado |
+| `ggVG=` | corrige a identação do arquivo inteiro |

--- a/docs/capitulo_6/edicoes_complexas.md
+++ b/docs/capitulo_6/edicoes_complexas.md
@@ -8,15 +8,19 @@ palavra e digita-se:
 deep
 ```
 Trocando letras de lugar:
-```
-xp .... com a letra seguinte
-xh[p .. com a letra anterior
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `xp` | com a letra seguinte |
+| `xh[p` | com a letra anterior |
+
 Trocando linhas de lugar:
-```
-ddp ... com a linha de baixo
-ddkP .. com a linha de cima
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `ddp` | com a linha de baixo |
+| `ddkP` | com a linha de cima |
+
 Tornando todo o texto maiúsculo
 ```
 gggUG

--- a/docs/capitulo_6/indentando.md
+++ b/docs/capitulo_6/indentando.md
@@ -1,6 +1,6 @@
-```
->> ..... Indenta a linha atual
-^t ..... Indenta a linha atual em modo de inserção
-^d ..... Remove indentação em modo de inserção
->ip .... indenta o parágrafo atual
-```
+| Comando | Descrição |
+|---------|-----------|
+| `>>` | Indenta a linha atual |
+| `^t` | Indenta a linha atual em modo de inserção |
+| `^d` | Remove indentação em modo de inserção |
+| `>ip` | indenta o parágrafo atual |

--- a/docs/capitulo_6/inserindo_linha_antes_e_depois.md
+++ b/docs/capitulo_6/inserindo_linha_antes_e_depois.md
@@ -5,20 +5,21 @@ isto pode ser obtido pelo seguinte mapeamento:
 :map ,t <Esc>:.s/^\(\s\+\)\(.*\)/\r\1\2\r/g<cr>
 ```
 Explicando:
-```
-: ................ entra no modo de comando
-map ,t ........... mapeia ,t para a função desejada
-<Esc> ............ ao executar sai do modo de inserção
-s/isto/aquilo/g .. substitui isto por aquilo
-: ................ inicia o modo de comando
-. ................ na linha corrente
-s ................ substitua
-^ ................ começo de linha
-\s\+ ............. um espaço ou mais (barras são escapes)
-.* ............... qualquer coisa depois
-\(grupo\) ........ agrupo para referenciar com \1
-\1 ............... repete na substituição o grupo 1
-\r ............... insere uma quebra de linha
-g ................ em todas as ocorrências da linha
-<cr> ............. Enter
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:` | entra no modo de comando |
+| `map ,t` | mapeia ,t para a função desejada |
+| `<Esc>` | ao executar sai do modo de inserção |
+| `s/isto/aquilo/g` | substitui isto por aquilo |
+| `:` | inicia o modo de comando |
+| `.` | na linha corrente |
+| `s` | substitua |
+| `^` | começo de linha |
+| `\s\+` | um espaço ou mais (barras são escapes) |
+| `.*` | qualquer coisa depois |
+| `\(grupo\)` | agrupo para referenciar com \1 |
+| `\1` | repete na substituição o grupo 1 |
+| `\r` | insere uma quebra de linha |
+| `g` | em todas as ocorrências da linha |
+| `<cr>` | Enter |

--- a/docs/capitulo_6/o_comando_global_g.md
+++ b/docs/capitulo_6/o_comando_global_g.md
@@ -9,10 +9,12 @@ Buscando um padrão e gravando em outro arquivo:
 Apenas imprimir linhas que contém determinada palavra, isto é útil
 quando você quer ter uma visão sobre um determina aspecto do seu arquivo
 vejamos:
-```
-:set nu ..... habilita numeração
-:g/Error/p .. apenas mostra as linhas correspondentes
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:set nu` | habilita numeração |
+| `:g/Error/p` | apenas mostra as linhas correspondentes |
+
 Para mostrar o as linhas correspondentes a um padrão, mesmo que a
 numeração de linha não esteja habilitada use
 `:g/padrão/\#`.

--- a/docs/capitulo_6/obtendo_informacoes_do_arquivo.md
+++ b/docs/capitulo_6/obtendo_informacoes_do_arquivo.md
@@ -2,11 +2,12 @@
 title: Obtendo informações do arquivo
 ---
 
-```
-ga ............. mostra o código do caractere em decimal hexa e octal
-^g ............. mostra o caminho e o nome do arquivo
-g^g ............ mostra estatísticas detalhadas do arquivo
-```
+| Comando | Descrição |
+|---------|-----------|
+| `ga` | mostra o código do caractere em decimal hexa e octal |
+| `^g` | mostra o caminho e o nome do arquivo |
+| `g^g` | mostra estatísticas detalhadas do arquivo |
+
 Obs: O código do caractere pode ser usado para substituições,
 especialmente em se tratando de caracteres de controle como tabulações
 `^I` ou final de linha DOS/Windows `\%x0d`. Você pode apagar os

--- a/docs/capitulo_6/selecionando_ou_deletando_o_conteudo_de_tags_HTML.md
+++ b/docs/capitulo_6/selecionando_ou_deletando_o_conteudo_de_tags_HTML.md
@@ -10,8 +10,9 @@ basta usar (em modo normal) as teclas
 vit ............... visual `inner tag | esta tag'
 ```
 Este recurso também funciona com parênteses
-```
-vi( ..... visual select
-vi" ..... visual select
-di( ..... delete inner (, ou seja, seu conteúdo
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `vi(` | visual select |
+| `vi"` | visual select |
+| `di(` | delete inner (, ou seja, seu conteúdo |

--- a/docs/capitulo_6/trabalhando_com_registradores.md
+++ b/docs/capitulo_6/trabalhando_com_registradores.md
@@ -5,17 +5,19 @@ por aspas seguido por uma letra. Exemplos: `"a`,
 
 Como copiar o texto para um registrador? É simples: basta especificar o
 nome do registrador antes:
-```
-"add ... apaga linha para o registrador "a"
-"bdd ... apaga linha para o registrador "b"
-"ap .... cola" o conteúdo do registrador "a"
-"bp .... cola" o conteúdo do registrador "b"
-"x3dd .. apaga 3 linhas para o registrador "x"
-"ayy  .. copia linha para o registrador "a"
-"a3yy .. copia 3 linhas para o registrador "a"
-"ayw  .. copia uma palavra para o registrador "a"
-"a3yw .. copia 3 palavras para o registrador "a"
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `"add` | apaga linha para o registrador "a" |
+| `"bdd` | apaga linha para o registrador "b" |
+| `"ap` | cola" o conteúdo do registrador "a" |
+| `"bp` | cola" o conteúdo do registrador "b" |
+| `"x3dd` | apaga 3 linhas para o registrador "x" |
+| `"ayy` | copia linha para o registrador "a" |
+| `"a3yy` | copia 3 linhas para o registrador "a" |
+| `"ayw` | copia uma palavra para o registrador "a" |
+| `"a3yw` | copia 3 palavras para o registrador "a" |
+
 No “modo de inserção”, como visto anteriormente, pode-se usar um atalho
 para colar rapidamente o conteúdo de um registrador.
 ```

--- a/docs/capitulo_6/usando_expressoes_regulares_em_buscas.md
+++ b/docs/capitulo_6/usando_expressoes_regulares_em_buscas.md
@@ -2,22 +2,23 @@
 title: Usando "Expressões Regulares" em buscas
 ---
 
-```
-/ ........... inicia uma busca (modo normal)
-\%x69 ....... código da letra `i'
-/\%x69 ...... localiza a letra `i' - hexadecimal 069
-\d .......... localiza números
-[3-8] ....... localiza números de 3 até 8
-^ ........... começo de linha
-$ ........... final de linha
-\+ .......... um ou mais
-/^\d\+$ ..... localiza somente dígitos
-/\r$ ........ localiza linhas terminadas com ^M
-/^\s*$ ...... localiza linhas vazias ou contendo apenas espaços
-/^\t\+ ...... localiza linhas que iniciam com tabs
-\s .......... localiza espaços
-/\s\+$ ...... localiza espaços no final da linha
-```
+| Comando | Descrição |
+|---------|-----------|
+| `/` | inicia uma busca (modo normal) |
+| `\%x69` | código da letra `i' |
+| `/\%x69` | localiza a letra `i' - hexadecimal 069 |
+| `\d` | localiza números |
+| `[3-8]` | localiza números de 3 até 8 |
+| `^` | começo de linha |
+| `$` | final de linha |
+| `\+` | um ou mais |
+| `/^\d\+$` | localiza somente dígitos |
+| `/\r$` | localiza linhas terminadas com ^M |
+| `/^\s*$` | localiza linhas vazias ou contendo apenas espaços |
+| `/^\t\+` | localiza linhas que iniciam com tabs |
+| `\s` | localiza espaços |
+| `/\s\+$` | localiza espaços no final da linha |
+
 ### Evitando escapes ao usar Expressões regulares
 
 O Vim possui um modo chamado “*very magic*” para uso em
@@ -82,11 +83,13 @@ Ao fazermos substituições em textos poderemos nos deparar com erros,
 pois [a-z] não inclui caracteres acentuados, as classes
 *POSIX* são a solução para este problema, pois adequam o
 sistema ao idioma local, esta é a mágica implementada por estas classes.
-```
-[:lower:] ...... letras minúsculas incluindo acentos
-[:upper:] ...... letras maiúsculas incluindo acentos
-[:punct:] ...... ponto, virgula, colchete, etc
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `[:lower:]` | letras minúsculas incluindo acentos |
+| `[:upper:]` | letras maiúsculas incluindo acentos |
+| `[:punct:]` | ponto, virgula, colchete, etc |
+
 Para usar estas classes fazemos:
 ```
 :%s/[[:lower:]]/\U&/g
@@ -108,10 +111,12 @@ lower ... letras minúsculas
 Nem todas as classes *POSIX* conseguem pegar caracteres
 acentuados, portanto deve-se habilitar o destaque colorido para buscas
 usando:
-```
-:set hlsearch .... destaque colorido para buscas
-:set incsearch ... busca incremental
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:set hlsearch` | destaque colorido para buscas |
+| `:set incsearch` | busca incremental |
+
 Dessa forma podemos testar nossas buscas antes de fazer uma
 substituição.
 

--- a/docs/capitulo_7/abrindo_e_fechando_janelas.md
+++ b/docs/capitulo_7/abrindo_e_fechando_janelas.md
@@ -1,11 +1,12 @@
-```
-Ctrl-w-s ...... Divide a janela horizontalmente (:split)
-Ctrl-w-v ...... Divide a janela verticalmente (:vsplit)
-Ctrl-w-o ...... Faz a janela atual ser a única (:only)
-Ctrl-w-n ...... Abre nova janela (:new)
-Ctrl-w-q ...... Fecha a janela atual (:quit)
-Ctrl-w-c ...... Fecha a janela atual (:close)
-```
+| Comando | Descrição |
+|---------|-----------|
+| `Ctrl-w-s` | Divide a janela horizontalmente (:split) |
+| `Ctrl-w-v` | Divide a janela verticalmente (:vsplit) |
+| `Ctrl-w-o` | Faz a janela atual ser a única (:only) |
+| `Ctrl-w-n` | Abre nova janela (:new) |
+| `Ctrl-w-q` | Fecha a janela atual (:quit) |
+| `Ctrl-w-c` | Fecha a janela atual (:close) |
+
 Lembrando que o Vim considera todos os arquivos como “buffers” portanto
 quando um arquivo é fechado, o que está sendo fechado é a visualização
 do mesmo, pois ele continua aberto no “buffer”.

--- a/docs/capitulo_7/alternando_entre_buffers_de_arquivo.md
+++ b/docs/capitulo_7/alternando_entre_buffers_de_arquivo.md
@@ -13,9 +13,11 @@ listam todos os arquivos que estão referenciados no buffer com suas
 respectivas “chaves” de referencia.
 
 Para trocar a visualização do Buffer atual pode-se usar:
-```
-:buffer# ...... Altera para o buffer anterior
-:b2 ........... Altera para o buffer cujo a chave é 2
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:buffer#` | Altera para o buffer anterior |
+| `:b2` | Altera para o buffer cujo a chave é 2 |
+
 Para os que preferem atalhos para alternar entre os buffers, é possível
 utilizar ‘Ctrl-6’ que tem o mesmo funcionamento do comando `:b#`

--- a/docs/capitulo_7/manipulando_janelas.md
+++ b/docs/capitulo_7/manipulando_janelas.md
@@ -1,13 +1,14 @@
-```
-Ctrl-w-w ......... Alterna entre janelas
-Ctrl-w-j ......... desce uma janela `j`
-Ctrl-w-k ......... sobe  uma janela `k`
-Ctrl-w-l ......... move para a janela da direita `l`
-Ctrl-w-h ......... move para a janela da esquerda `h`
-Ctrl-w-r ......... Rotaciona janelas na tela
-Ctrl-w-+ ......... Aumenta o espaço da janela atual
-Ctrl-w-- ......... Diminui o espaço da janela atual
-```
+| Comando | Descrição |
+|---------|-----------|
+| `Ctrl-w-w` | Alterna entre janelas |
+| `Ctrl-w-j` | desce uma janela `j` |
+| `Ctrl-w-k` | sobe  uma janela `k` |
+| `Ctrl-w-l` | move para a janela da direita `l` |
+| `Ctrl-w-h` | move para a janela da esquerda `h` |
+| `Ctrl-w-r` | Rotaciona janelas na tela |
+| `Ctrl-w-+` | Aumenta o espaço da janela atual |
+| `Ctrl-w--` | Diminui o espaço da janela atual |
+
 Pode-se mapear um atalho para redimensionar janelas com as teclas `+`
 e `-`.
 ```

--- a/docs/capitulo_7/modos_de_divisao_da_janela.md
+++ b/docs/capitulo_7/modos_de_divisao_da_janela.md
@@ -10,11 +10,13 @@ tempo, e isso pode ser feito utilizando *tab* ou *split*.
 A partir do Vim 7 foi disponibilizada a função de abrir arquivos em
 abas, portanto é possível ter vários buffers abertos em abas distintas e
 alternar entre elas facilmente. Os comandos para utilização das abas são:
-```
-:tabnew ........... Abre uma nova tab
-:tabprevious ...... Vai para a tab anterior
-:tabnext .......... Vai para a próxima tab
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:tabnew` | Abre uma nova tab |
+| `:tabprevious` | Vai para a tab anterior |
+| `:tabnext` | Vai para a próxima tab |
+
 ### Utilizando split horizontal
 
 Enquanto os comandos referentes a *tab* deixam a janela

--- a/docs/capitulo_7/salvando_e_saindo.md
+++ b/docs/capitulo_7/salvando_e_saindo.md
@@ -1,5 +1,6 @@
 É possível salvar todas as janelas facilmente, assim como sair também:
-```
-:wall ............. salva todos `write all'
-:qall ............. fecha todos `quit all'
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:wall` | salva todos `write all' |
+| `:qall` | fecha todos `quit all' |

--- a/docs/capitulo_8/gravando_comandos.md
+++ b/docs/capitulo_8/gravando_comandos.md
@@ -24,18 +24,20 @@ qa
 No modo Normal. Tudo o que for digitado a partir de então, será gravado
 no registrador ‘a’ até que seja concluído com o comando `<Esc>q` novamente
 (no modo Normal). Assim, soluciona-se o problema:
-```
-<Esc> ....... para garantir que estamos no modo normal
-qa .......... inicia a gravação da macro `a'
-I ........... entra no modo de inserção no começo da linha
-#include " .. insere #include "
-<Esc> ....... sai do modo de inserção
-A" .......... insere o último caractere
-<Esc> ....... sai do modo de inserção
-j ........... desce uma linha
-<Esc> ....... sai do modo de inserção
-q ........... para a gravação da macro
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `<Esc>` | para garantir que estamos no modo normal |
+| `qa` | inicia a gravação da macro `a' |
+| `I` | entra no modo de inserção no começo da linha |
+| `#include "` | insere #include " |
+| `<Esc>` | sai do modo de inserção |
+| `A"` | insere o último caractere |
+| `<Esc>` | sai do modo de inserção |
+| `j` | desce uma linha |
+| `<Esc>` | sai do modo de inserção |
+| `q` | para a gravação da macro |
+
 Agora só é preciso posicionar o cursor na primeira letra de uma linha
 como esta
 ```c

--- a/docs/capitulo_8/guardando_trechos_em_registros.md
+++ b/docs/capitulo_8/guardando_trechos_em_registros.md
@@ -13,8 +13,9 @@ letras do alfabeto, em seguida uma ação por exemplo, ‘y’
 (copiar) ‘d’ (apagar). Depois, mover o cursor para a linha
 desejada e colar com `"rp`, onde ‘r’ corresponde ao
 registrador para onde o trecho foi copiado.
-```
-"ayy ... copia a linha atual para o registrador `a'
-"ap  ... cola o conteúdo do registrador `a' abaixo
-"bdd ... apaga a linha atual para o registrador `b'
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `"ayy` | copia a linha atual para o registrador `a' |
+| `"ap` | cola o conteúdo do registrador `a' abaixo |
+| `"bdd` | apaga a linha atual para o registrador `b' |

--- a/zensical.toml
+++ b/zensical.toml
@@ -228,6 +228,7 @@ font = false
 favicon = "imgs/favicon.ico"
 features = [
   "content.action.edit",
+  "content.code.copy",
   "content.footnote.tooltips",
   "content.tabs.link",
   "header.autohide",


### PR DESCRIPTION
## Resumo

- Ativa a feature `content.code.copy` do tema, mostrando um botão de copiar em blocos de código.
- Vários blocos de código no livro na verdade são listas de referência no formato `comando ...... descrição`, herdadas do jeito que o PDF original as diagramava (alinhamento com pontos de preenchimento, não código de fato). Com o botão de cópia ativado, essas listas passariam a exibir um botão sem sentido — copiar "gUU ....... converte a linha para maiúsculo" não é algo útil de colar em lugar nenhum.
- 55 arquivos com esse padrão foram convertidos para tabelas Markdown (que não recebem botão de copiar), mantendo os blocos de código originais nos casos em que o conteúdo é de fato um comando real para digitar/copiar (ex: `vim texto.txt`, `:e /caminho/arquivo`).

## Plano de teste

- [x] Build local com `zensical build` sem erros
- [x] Varredura no HTML gerado: nenhuma tabela ficou malformada, nenhuma tag HTML foi engolida dentro de célula de tabela
- [x] Conferência visual no navegador: página convertida em tabela não exibe botão de copiar; página com comandos reais exibe o botão em cada bloco