### PR TITLE
Corrige comandos incorretos do capítulo 2

### DIFF
--- a/docs/capitulo_2/abrindo_o_ultimo_arquivo_rapidamente.md
+++ b/docs/capitulo_2/abrindo_o_ultimo_arquivo_rapidamente.md
@@ -2,7 +2,9 @@
 title: Abrindo o último arquivo rapidamente
 ---
 
-O Vim guarda um registrador para cada arquivo editado veja mais no capítulo [Registradores](../capitulo_5/registradores.md).
+O Vim guarda uma marca para cada arquivo editado recentemente, gravada no
+arquivo `viminfo` (veja `:h viminfo`). Para conhecer os registradores, que são
+um recurso distinto, veja o capítulo [Registradores](../capitulo_5/registradores.md).
 
 | Comando | Descrição |
 |---------|-----------|

--- a/docs/capitulo_2/comparando_arquivos_com_vimdiff.md
+++ b/docs/capitulo_2/comparando_arquivos_com_vimdiff.md
@@ -8,9 +8,10 @@ diferenças entre dois arquivos faz-se:
 
 | Comando | Descrição |
 |---------|-----------|
-| `diff arquivo1.txt arquivo2.txt` | exibe as diferenças |
-| `]c` | mostra próxima diferença |
-| `vim -d` | outro modo de abrir o vimdiff mode |
+| `vimdiff arquivo1.txt arquivo2.txt` | exibe as diferenças |
+| `]c` | mostra a próxima diferença |
+| `[c` | mostra a diferença anterior |
+| `vim -d arquivo1.txt arquivo2.txt` | outro modo de abrir o vimdiff |
 
 Para usuários do GNU/Linux é possível ainda checar diferenças
 remotamente assim:

--- a/docs/capitulo_2/copiar_colar_deletar.md
+++ b/docs/capitulo_2/copiar_colar_deletar.md
@@ -32,8 +32,8 @@ O que foi deletado ou copiado pode ser colado:
 |---------|-----------|
 | `p` | cola o que foi copiado ou deletado abaixo |
 | `P` | cola o que foi copiado ou deletado acima |
-| `[p` | cola o que foi copiado ou deletado antes do cursor |
-| `]p` | cola o que foi copiado ou deletado após o cursor |
+| `[p` | cola acima, ajustando a indentação à da linha atual |
+| `]p` | cola abaixo, ajustando a indentação à da linha atual |
 
 ### Deletando uma parte do texto
 
@@ -44,7 +44,7 @@ O comando `d` remove o conteúdo para a memória.
 | `x` | apaga o caractere sob o cursor |
 | `xp` | troca letras de lugar |
 | `ddp` | troca linhas de lugar |
-| `d5x` | apaga os próximos 5 caracteres |
+| `5x` | apaga os próximos 5 caracteres |
 | `dd` | apaga a linha atual |
 | `5dd` | apaga 5 linhas (também pode ser: d5d) |
 | `d5G` | apaga até a linha 5 |

--- a/docs/capitulo_2/editando_em_modo_comando.md
+++ b/docs/capitulo_2/editando_em_modo_comando.md
@@ -36,7 +36,7 @@ linhas contendo a palavra ‘padrão’.
 |---------|-----------|
 | `:v/padrão/d` | apaga linhas que não contenham "padrão" |
 | `:v/\S/d` | apaga linhas vazias |
-| `\S` | significa "string" |
+| `\S` | qualquer caractere que não seja espaço em branco |
 
 A opção acima equivale a `:g!/padrão/d`. Para ler mais sobre o comando
 “global” utilizado nesta seção veja o capítulo [O comando global "g"](../capitulo_6/o_comando_global_g.md).

--- a/docs/capitulo_2/salvando.md
+++ b/docs/capitulo_2/salvando.md
@@ -2,12 +2,16 @@ A maneira mais simples de salvar um arquivo, é usar o comando:
 ```
 :w
 ```
-Para especificar um novo nome para o arquivo, simplesmente digite:
+Para gravar o conteúdo em outro arquivo, simplesmente digite:
 ```
-:w! >> “file”
+:w arquivo
 ```
-O conteúdo será gravado no arquivo `file` e você continuará
-no arquivo original.
+O conteúdo será gravado no arquivo `arquivo` e você continuará
+no arquivo original. Para anexar o conteúdo ao final de um arquivo já
+existente, em vez de sobrescrevê-lo, usa-se:
+```
+:w >> arquivo
+```
 
 Também existe o comando:
 ```

--- a/docs/capitulo_2/substituindo_tabulacoes_por_espacos.md
+++ b/docs/capitulo_2/substituindo_tabulacoes_por_espacos.md
@@ -26,7 +26,7 @@ Explicando:
 | `s` | substitua |
 | `/` | padrão de busca |
 | `\s` | localiza espaço |
-| `\{4,}` | quatro vezes |
+| `\{4,}` | quatro ou mais vezes |
 | `/` | inicio da substituição |
 | `<Ctrl-i>` | pressione Ctrl-i para inserir `<Tab>` |
 | `/` | fim da substituição |


### PR DESCRIPTION
Parte da revisão dos comandos Vim do livro. Este MR trata apenas do capítulo 2.

## Correções

| Arquivo | Antes | Depois |
|---|---|---|
| `comparando_arquivos_com_vimdiff.md` | `diff arquivo1.txt arquivo2.txt` | `vimdiff arquivo1.txt arquivo2.txt` |
| `copiar_colar_deletar.md` | `d5x` | `5x` |
| `copiar_colar_deletar.md` | `[p`/`]p` = "cola antes/depois do cursor" | "cola acima/abaixo ajustando a indentação" |
| `editando_em_modo_comando.md` | `\S` = "string" | "caractere que não é espaço em branco" |
| `abrindo_o_ultimo_arquivo_rapidamente.md` | "o Vim guarda um registrador para cada arquivo" | marcas gravadas no `viminfo` |
| `salvando.md` | `:w! >> “file”` | `:w arquivo` (e `:w >> arquivo` para anexar) |
| `substituindo_tabulacoes_por_espacos.md` | `\{4,}` = "quatro vezes" | "quatro ou mais vezes" |

## Detalhes

- **`diff` → `vimdiff`**: a tabela ficava sob o título "Comparando arquivos com o vimdiff", mas o comando listado era o `diff` do shell, que não abre o Vim. Aproveitei para incluir `[c` (diferença anterior) e completar `vim -d` com os arquivos.
- **`d5x`**: `d` exige um movimento e `x` não é um. O comando não funciona.
- **`[p` / `]p`**: como estavam descritos, eram indistinguíveis de `P` e `p`. O que os caracteriza é ajustar a indentação do texto colado à da linha atual.
- **`'0` e `'1`**: são marcas persistidas no `viminfo`, um recurso diferente dos registradores. O link para o capítulo de registradores foi mantido, mas agora sem afirmar que são a mesma coisa.
- **`:w! >> “file”`**: além das aspas tipográficas herdadas do PDF, `>>` anexa ao final de um arquivo, o que não corresponde ao texto ("especificar um novo nome"). Separei os dois casos.