### PR TITLE
Corrige comandos incorretos do capítulo 3

### DIFF
--- a/docs/capitulo_3/movendo-se_no_documento.md
+++ b/docs/capitulo_3/movendo-se_no_documento.md
@@ -79,10 +79,9 @@ W ..... pula para próxima palavra (desconsidera hífens)
 E ..... pula para o final da próxima palavra (desconsidera
         hifens)
 e ..... move o cursor para o final da próxima palavra
-zt .... movo o cursor para o topo da página
-zm .... move o cursor para o meio da página
-zz .... move a página de modo com que o cursor fique no
-        centro
+zt .... rola a tela deixando a linha atual no topo
+zz .... rola a tela deixando a linha atual no centro
+zb .... rola a tela deixando a linha atual embaixo
 n ..... move o cursor para a próxima ocorrência da busca
 N ..... move o cursor para a ocorrência anterior da busca
 ```

--- a/docs/capitulo_3/paginando.md
+++ b/docs/capitulo_3/paginando.md
@@ -39,7 +39,7 @@ Ou voltar ao arquivo anterior
 É possível ainda “rebobinar” sua lista de arquivos.
 
 ```
-:rew[wind]
+:rew[ind]
 ```
 
 Ir para o primeiro

--- a/docs/capitulo_3/usando_marcas.md
+++ b/docs/capitulo_3/usando_marcas.md
@@ -18,7 +18,7 @@ Para voltar ao ponto do último salto:
 ''
 ```
 
-Para deletar de até a marca ‘a’ (em modo normal):
+Para deletar da linha atual até a marca ‘a’ (em modo normal):
 
 ```
 d'a


### PR DESCRIPTION
Parte da revisão dos comandos Vim do livro. Este MR trata apenas do capítulo 3.

## Correções

| Arquivo | Antes | Depois |
|---|---|---|
| `movendo-se_no_documento.md` | `zm` = "move o cursor para o meio da página" | `zb` = "rola a tela deixando a linha atual embaixo" |
| `paginando.md` | `:rew[wind]` | `:rew[ind]` |
| `usando_marcas.md` | "Para deletar de até a marca" | "Para deletar da linha atual até a marca" |

## Detalhes

- **`zm`**: é o comando de dobras (*fold more*), que subtrai um do `foldlevel` — nada a ver com posicionar o cursor. O comando que a lista queria descrever já estava logo abaixo (`zz`). Troquei a entrada por `zb`, que faltava, deixando o trio `zt`/`zz`/`zb` completo e coerente.
- Aproveitei para reescrever as três descrições: esses comandos rolam a tela em torno da linha atual, não movem o cursor.
- **`:rew[wind]`**: a forma correta é `:rew[ind]` — como estava, sugeria que `:reww` seria uma abreviação válida.