### PR TITLE
Corrige comandos incorretos do capítulo 5

### DIFF
--- a/docs/capitulo_5/como_colocar_um_pedaco_de_texto_em_um_registrador.md
+++ b/docs/capitulo_5/como_colocar_um_pedaco_de_texto_em_um_registrador.md
@@ -5,13 +5,13 @@ title: Como colocar um pedaço de texto em um registrador?
 | Comando | Descrição |
 |---------|-----------|
 | `<Esc>` | vai para o modo normal |
-| `"a10j` | coloca no registrador `a' as próximas 10 linhas `10j' |
+| `"ay10j` | coloca no registrador `a' as próximas 10 linhas `10j' |
 
 Pode-se fazer:
 ```
 <Esc> ...... para ter certeza que está em modo normal
 "ap ........ registrador a `paste', ou seja, cole
-``
+```
 Em modo de inserção faz-se:
 ```
 Ctrl-r a
@@ -21,7 +21,7 @@ de se colocar em uma busca ou substituição, nestes casos pode-se usar os
 seguintes comandos:
 ```
 "ayl ............. copia para o registrador `a' o caractere sob o cursor
-:%s/<c-r>a/char .. subsitui o conteúdo do registrador `a' por char
+:%s/<c-r>a/char .. substitui o conteúdo do registrador `a' por char
 ```
 Pode-se ainda usar esta técnica para copiar rapidamente comentários do
 `bash`[^1], representados pelo caracteres `#`, em *modo

--- a/docs/capitulo_5/como_definir_um_registrador_no_vimrc.md
+++ b/docs/capitulo_5/como_definir_um_registrador_no_vimrc.md
@@ -14,26 +14,27 @@ Você pode criar uma variável no vimrc assim:
 
 Pode também dizer ao Vim algo como...
 ```
-:let @d=strftime("c")<Enter>
+:let @d=strftime("%c")<Enter>
 ```
 Neste caso estou dizendo a ele que guarde na variável 'd',
-o valor da data do sistema `strftime("c")` ou então
+o valor da data do sistema `strftime("%c")` ou então
 cole isto no vimrc:
 ```
-let @d=strftime("c")<cr>
+let @d=strftime("%c")
 ```
 A diferença entre digitar diretamente um comando e adicioná-lo ao
 vimrc é que uma vez no vimrc o registrador em
 questão estará sempre disponível, observe também as sutis diferenças, um
 Enter inserido manualmente é apenas uma indicação de uma
-ação que você fará pressionando a tecla especificada, já o comando
-mapeado vira `<cr>`, veja ainda que no vimrc os dois
+ação que você fará pressionando a tecla especificada, e por isso não
+aparece na versão do vimrc; nos mapeamentos, por outro lado, o Enter
+precisa ser escrito como `<cr>`. Veja ainda que no vimrc os dois
 pontos `:` somem.
 
 Pode mapear tudo isto
 ```
-let @d=strftime("c")<cr>
-imap ,d <cr-r>d
+let @d=strftime("%c")
+imap ,d <c-r>d
 nmap ,d "dp
 ```
 As atribuições acima correspondem a:
@@ -48,7 +49,7 @@ E digitar ,d normalmente
 
 Desmistificando o strftime
 ```
-" d=dia m=mes Y=ano H=hora M=minuto c=data-completa
+" %d=dia %m=mes %Y=ano %H=hora %M=minuto %c=data-completa
 :h strftime ........ ajuda completa sobre o comando
 ```
 e inserir em modo normal assim:

--- a/docs/capitulo_5/como_selecionar_blocos_verticais_de_texto.md
+++ b/docs/capitulo_5/como_selecionar_blocos_verticais_de_texto.md
@@ -16,6 +16,6 @@ O comando acima quer dizer
 
 | Comando | Descrição |
 |---------|-----------|
-| ``para o registrador `a'`` | "a |
-| `copie` | `y` |
-| `o parágrafo atual` | `inner paragraph` |
+| `"a` | para o registrador `a' |
+| `y` | copie |
+| `ip` | o parágrafo atual (*inner paragraph*) |

--- a/docs/capitulo_5/manipulando_registradores.md
+++ b/docs/capitulo_5/manipulando_registradores.md
@@ -1,6 +1,6 @@
 ```
 :let @a=@_   ... limpa o registrador a
-:let @a=``'' ... limpa o registrador a
+:let @a=""   ... limpa o registrador a
 :let @a=@"   ... salva registrador sem nome *N*
 :let @*=@a   ... copia o registrador para o buffer de colagem
 :let @*=@:   ... copia o ultimo comando para o buffer de
@@ -19,7 +19,8 @@ Em modo de inserção
 | `<C-R>[0-9a-z]` | Insere registradores 0-9 e a-z |
 | `<C-R>%` | Insere o nome do arquivo |
 | `<C-R>=somevar` | Insere o conteúdo de uma variável |
-| `<C-R><C-A>` | Insere `Big-Words' veja seção 2.1 |
+| `<C-R><C-W>` | Insere a palavra sob o cursor |
+| `<C-R><C-A>` | Insere a WORD sob o cursor (delimitada por espaços) |
 
 Um exemplo: pré-carregando o nome do arquivo no registrador `n`.
 

--- a/docs/capitulo_5/registrador_de_expressoes.md
+++ b/docs/capitulo_5/registrador_de_expressoes.md
@@ -34,7 +34,7 @@ w .............. pula para o número `1'
 <Ctrl-a> ....... incrementa o número (agora 2)
 4w ............. avança 4 palavras até 150
 "ndw ........... apaga o `150' para o registrador "n
-a .............. entra em modo de inserção
+i .............. entra em modo de inserção
 Ctrl-r = ....... abre o registrador de expressões
 Ctrl-r n + 150   insere dentro do registrador de expressões
                  o registrador "n

--- a/docs/capitulo_5/registradores.md
+++ b/docs/capitulo_5/registradores.md
@@ -19,9 +19,9 @@ múltipla) etc. Vamos aos detalhes.
 
 -   O registrador de expressões "=
 
--   Os registrador de seleção e "\*, "+ and " 
+-   Os registradores de seleção e de arrastar-e-soltar "\*, "+ e "\~ 
 
--   O registrador "o"
+-   O registrador buraco negro "\_
 
 -   registrador do último padrão de busca "/
 

--- a/docs/capitulo_5/registradores_de_arrastar_e_mover.md
+++ b/docs/capitulo_5/registradores_de_arrastar_e_mover.md
@@ -9,7 +9,7 @@ mouse). Já o registrador
 ```
 é o denominado "área de transferência", normalmente utilizado para se
 transferir conteúdos entre aplicações—este registrador é preenchido, por
-exemplo, usando-se a típica combinação Ctrl-v encontrada em
+exemplo, usando-se a típica combinação Ctrl-c (copiar) encontrada em
 muitas aplicações. Finalmente, o registrador
 ```
 "~


### PR DESCRIPTION
Parte da revisão dos comandos Vim do livro. Este MR trata apenas do capítulo 5.

## Correções

| Arquivo | Antes | Depois |
|---|---|---|
| `como_colocar_um_pedaco_de_texto_em_um_registrador.md` | cerca fechada com `` `` `` | ` ``` ` |
| `como_colocar_um_pedaco_de_texto_em_um_registrador.md` | `"a10j` | `"ay10j` |
| `como_definir_um_registrador_no_vimrc.md` | `strftime("c")` | `strftime("%c")` |
| `como_definir_um_registrador_no_vimrc.md` | `imap ,d <cr-r>d` | `imap ,d <c-r>d` |
| `manipulando_registradores.md` | ``:let @a=`` `` '' `` | `:let @a=""` |
| `manipulando_registradores.md` | `<C-R><C-A>` = "Insere `Big-Words' veja seção 2.1" | "Insere a WORD sob o cursor" |
| `registradores.md` | `O registrador "o"` | `O registrador buraco negro "_` |
| `registradores_de_arrastar_e_mover.md` | `"+` preenchido com `Ctrl-v` | `Ctrl-c` |
| `registrador_de_expressoes.md` | `a` (entra em inserção) | `i` |
| `como_selecionar_blocos_verticais_de_texto.md` | colunas da tabela invertidas | comando na coluna "Comando" |

## Detalhes

- **Cerca quebrada**: a linha 14 fechava o bloco com duas crases em vez de três. Na prática, todo o restante do arquivo era renderizado como código.
- **`"a10j`**: `"a` só escolhe o registrador; sem o operador `y` nada é copiado. O `10j` sozinho apenas move o cursor.
- **`strftime("c")`**: sem `%` a função devolve a string literal `c`. Corrigi também a legenda logo abaixo, que listava `d`, `m`, `Y`, `H`, `M`, `c` sem os `%`.
- **`let @d=strftime(...)<cr>`**: o `<cr>` no fim tornava a linha do vimrc inválida. O texto em volta explicava a distinção entre o `<Enter>` como notação e o `<cr>` de mapeamentos — reescrevi a frase para preservar essa explicação sem ensinar a linha quebrada.
- **`<C-R><C-A>`**: a descrição citava "seção 2.1", referência órfã da numeração do PDF original. Aproveitei para incluir `<C-R><C-W>`, que faltava e é o mais usado dos dois.
- **`O registrador "o"`**: não existe no Vim. Pelo contexto era o buraco negro `"_`, que inclusive já tem página própria neste capítulo. Na mesma lista, o item dos registradores de seleção estava truncado, com "and" sem traduzir e sem o `"~`.
- **`Ctrl-v` → `Ctrl-c`**: `Ctrl-v` cola; quem preenche a área de transferência é `Ctrl-c`.
- **`a` → `i`**: após `"ndw` sobre `150,` o cursor fica sobre a vírgula. Com `a` o resultado sai como `,300` em vez de `300,`.