### PR TITLE
Corrige comandos incorretos do capítulo 6

### DIFF
--- a/docs/capitulo_6/buscando_em_um_intervalo_de_linhas.md
+++ b/docs/capitulo_6/buscando_em_um_intervalo_de_linhas.md
@@ -1,6 +1,6 @@
 Para buscar entre as linhas 10 e 50 por um padrão qualquer fazemos:
 ```
-/padrao\%>10l\$<50l
+/\%>10l\%<50l padrao
 ```
 Esta e outras boas dicas podem ser lidas no site
 [vim-faq](http://vimdoc.sourceforge.net/htmldoc/vimfaq.html).

--- a/docs/capitulo_6/corrigindo_a_indentacao_de_codigos.md
+++ b/docs/capitulo_6/corrigindo_a_indentacao_de_codigos.md
@@ -8,4 +8,4 @@ Selecione o bloco de código, por exemplo
 |---------|-----------|
 | `vip` | visual ``inner paragraph'' (selecione este parágrafo) |
 | `=` | corrige a indentação do bloco de texto selecionado |
-| `ggVG=` | corrige a identação do arquivo inteiro |
+| `ggVG=` | corrige a indentação do arquivo inteiro |

--- a/docs/capitulo_6/dicas.md
+++ b/docs/capitulo_6/dicas.md
@@ -1,9 +1,11 @@
-Para colocar a última busca em uma substituição faça:
+Para colocar a última busca em uma substituição, pressione `Ctrl-r`
+seguido de `/` no lugar do padrão:
 ```
-:%s/Ctrl-r//novo/g
+:%s/<Ctrl-r>//novo/g
 ```
-A dupla barra corresponde ao ultimo padrão procurado, e portanto o
-comando abaixo fará a substituição da ultima busca por casinha:
+Mais simples ainda: deixar o padrão vazio já faz o Vim reaproveitar a
+última busca, e portanto o comando abaixo fará a substituição da última
+busca por casinha:
 ```
 :%s//casinha/g
 ```

--- a/docs/capitulo_6/dicas_da_lista_vi-br.md
+++ b/docs/capitulo_6/dicas_da_lista_vi-br.md
@@ -28,8 +28,7 @@ texto1005texto    // linha i+4
 Ou seja, somasse 1 a cada um dos números entre os textos especificando
 como range as linhas i,i+4
 ```
-:10,20! awk 'BEGIN{i=1}{if (match($0, ``+'')) print ``o''
-(substr($0, RSTART, RLENGTH) + i++) ``o'``}''
+:10,20! awk 'BEGIN{i=1}{if (match($0, /[0-9]+/)) print substr($0,1,RSTART-1) (substr($0,RSTART,RLENGTH) + i++) substr($0,RSTART+RLENGTH)}'
 ```
 Mas muitos sistemas não tem awk, e logo a melhor solução
 mesmo é usar o Vim:

--- a/docs/capitulo_6/exemplos.md
+++ b/docs/capitulo_6/exemplos.md
@@ -2,8 +2,8 @@ Busca usando alternativas:
 ```
 /end\(if\|while\|for\)
 ```
-Buscará ‘if’, ‘while’ e ‘for’.
-Observe que é necessário ‘escapar’ os caracteres `\(`, `\`| e `\)`, caso
+Buscará ‘endif’, ‘endwhile’ e ‘endfor’.
+Observe que é necessário ‘escapar’ os caracteres `\(`, `\|` e `\)`, caso
 contrário eles serão interpretados como caracteres comuns.
 
 Quebra de linha
@@ -20,7 +20,7 @@ Usando `\c` o Vim encontrará “*palavra*”,
 de configuração “vimrc” veja o capítulo
 [Como editar preferências no Vim](../capitulo_12/como_editar_preferencias_no_vim.md).
 ```
-set ignorecase .. ignora maiúsculas e minúsculas na bucsca
+set ignorecase .. ignora maiúsculas e minúsculas na busca
 set smartcase ... se busca contiver maiúsculas ele passa a
                   considerá-las
 set hlsearch .... mostra o que está sendo buscado em cores
@@ -44,8 +44,8 @@ Multilinha
 ```
 /Hello\_s\+World
 ```
-Buscará ‘World’, separado por qualquer número de espaços, incluindo
-quebras de linha. Buscará as três sequências:
+Buscará ‘Hello’ seguido de ‘World’, separados por qualquer número de
+espaços, incluindo quebras de linha. Buscará as três sequências:
 ```
 Hello World
 
@@ -70,7 +70,7 @@ só linha vazia.
 ```
 :%s/\(^\n\{2,}\)/\r/g
 ```
-Você pode criar um mapeamento e colocar no seu  /.vimrc
+Você pode criar um mapeamento e colocar no seu `~/.vimrc`
 ```
 map ,s <Esc>:%s/\(^\n\{2,}\)/\r/g<cr>
 ```

--- a/docs/capitulo_6/filtrando_arquivos_com_o_vimgrep.md
+++ b/docs/capitulo_6/filtrando_arquivos_com_o_vimgrep.md
@@ -4,7 +4,7 @@ dicas à partir da nossa pasta pessoal pela palavra ‘dicas’ em todos os
 arquivos com extensão ‘txt’.
 ```
 ~/ ............ equivale a /home/user
-:lvimgrep /dicas/gj ~/**/*.txt | ls
+:lvimgrep /dicas/gj ~/**/*.txt | lopen
 :vimgrep /dicas/gj **/*.txt | copen
 :vimgrep dicas **/*.txt | copen
 :h lvim ....... ajuda sobre o comando

--- a/docs/capitulo_6/inserindo_linha_antes_e_depois.md
+++ b/docs/capitulo_6/inserindo_linha_antes_e_depois.md
@@ -18,7 +18,7 @@ Explicando:
 | `^` | começo de linha |
 | `\s\+` | um espaço ou mais (barras são escapes) |
 | `.*` | qualquer coisa depois |
-| `\(grupo\)` | agrupo para referenciar com \1 |
+| `\(grupo\)` | agrupa um trecho para referenciar com \1 |
 | `\1` | repete na substituição o grupo 1 |
 | `\r` | insere uma quebra de linha |
 | `g` | em todas as ocorrências da linha |

--- a/docs/capitulo_6/o_comando_global_g.md
+++ b/docs/capitulo_6/o_comando_global_g.md
@@ -15,9 +15,9 @@ vejamos:
 | `:set nu` | habilita numeração |
 | `:g/Error/p` | apenas mostra as linhas correspondentes |
 
-Para mostrar o as linhas correspondentes a um padrão, mesmo que a
-numeração de linha não esteja habilitada use
-`:g/padrão/\#`.
+Para mostrar as linhas correspondentes a um padrão, já numeradas, mesmo
+que a numeração de linha não esteja habilitada, use
+`:g/padrão/#`.
 
 numerar linhas:
 ```
@@ -102,7 +102,7 @@ g ........ global
 / ........ inicio de um padrão
 ^ ........ começo de linha
 Chapter .. palavra literal
-/ ........ fim do parão
+/ ........ fim do padrão
 t ........ copia
 . ........ linha atual
 s ........ substitua

--- a/docs/capitulo_6/substituicoes.md
+++ b/docs/capitulo_6/substituicoes.md
@@ -2,8 +2,8 @@
 title: Substituições
 ---
 
-Para fazer uma busca, certifique-se de que está em modo normal, em
-seguida digite use o comando ‘s’, conforme será explicado.
+Para fazer uma substituição, certifique-se de que está em modo normal e
+em seguida use o comando ‘s’, conforme será explicado.
 
 Para substituir “foo” por “bar” na linha atual:
 ```

--- a/docs/capitulo_6/trabalhando_com_registradores.md
+++ b/docs/capitulo_6/trabalhando_com_registradores.md
@@ -10,8 +10,8 @@ nome do registrador antes:
 |---------|-----------|
 | `"add` | apaga linha para o registrador "a" |
 | `"bdd` | apaga linha para o registrador "b" |
-| `"ap` | cola" o conteúdo do registrador "a" |
-| `"bp` | cola" o conteúdo do registrador "b" |
+| `"ap` | cola o conteúdo do registrador "a" |
+| `"bp` | cola o conteúdo do registrador "b" |
 | `"x3dd` | apaga 3 linhas para o registrador "x" |
 | `"ayy` | copia linha para o registrador "a" |
 | `"a3yy` | copia 3 linhas para o registrador "a" |

--- a/docs/capitulo_6/usando_expressoes_regulares_em_buscas.md
+++ b/docs/capitulo_6/usando_expressoes_regulares_em_buscas.md
@@ -69,13 +69,13 @@ raciocínio, como “remover os dígitos”.
 s ......... substitua
 / ......... inicia padrão de busca
 \d ........ ao encontrar um dígito
-/ ......... subtituir por
+/ ......... substituir por
 vazio ..... exato, substituir por vazio
-/g ........ a expressão se torna gulosa
+/g ........ a substituição se torna global
 ```
-Por guloso - `/g` - se entende que ele pode e deve tentar achar mais de
-uma ocorrência do padrão de busca na mesma linha. Caso não seja gulosa,
-a expressão irá apenas casar com a primeira ocorrência em cada linha.
+A opção `g` — de *global* — faz a substituição valer para todas as
+ocorrências do padrão em cada linha. Sem ela, apenas a primeira
+ocorrência de cada linha é substituída.
 
 #### Classes *POSIX* para uso em Expressões Regulares
 


### PR DESCRIPTION
Parte da revisão dos comandos Vim do livro. Este MR trata apenas do capítulo 6.

## Correções

| Arquivo | Antes | Depois |
|---|---|---|
| `filtrando_arquivos_com_o_vimgrep.md` | `:lvimgrep ... \| ls` | `\| lopen` |
| `o_comando_global_g.md` | `:g/padrão/\#` | `:g/padrão/#` |
| `buscando_em_um_intervalo_de_linhas.md` | `/padrao\%>10l\$<50l` | `/\%>10l\%<50l padrao` |
| `dicas_da_lista_vi-br.md` | `awk` com aspas TeX, quebrado em duas linhas | comando `awk` válido |
| `dicas.md` | `:%s/Ctrl-r//novo/g` | `:%s/<Ctrl-r>//novo/g` + explicação separada |
| `usando_expressoes_regulares_em_buscas.md` | `g` = "gulosa" | `g` = global |
| `substituicoes.md` | "Para fazer uma busca..." | "Para fazer uma substituição..." |
| `exemplos.md` | `/end\(if\|while\|for\)` busca "if, while, for" | busca "endif, endwhile, endfor" |
| `exemplos.md` | `/Hello\_s\+World` "buscará World" | "buscará Hello seguido de World" |

Mais quatro erros de digitação: `identação`, `parão`, `agrupo`, `cola"` (aspas solta em duas linhas de tabela).

## Detalhes

- **`| ls`**: `:ls` lista os buffers abertos. Quem abre a *location list* preenchida pelo `:lvimgrep` é `:lopen` — as duas linhas seguintes do mesmo bloco já usavam `:copen` corretamente para o `:vimgrep`.
- **`\#`**: a barra invertida impedia o funcionamento. O `#` do `:g` imprime as linhas já numeradas, que é justamente o que o texto promete.
- **Busca por intervalo**: `\$<50l` não é sintaxe válida; o átomo é `\%<50l`. Além disso, no Vim os átomos de posição vêm antes do padrão.
- **`awk`**: reconstruí o comando a partir do resultado esperado descrito na própria página e verifiquei a saída com a entrada de exemplo:

  ```
  $ printf 'texto1000texto\ntexto1000texto\ntexto1000texto\n' | awk '...'
  texto1001texto
  texto1002texto
  texto1003texto
  ```

- **`g` "gulosa"**: guloso/preguiçoso é sobre quanto um quantificador consome. A opção `g` do `:s` é a de abrangência (todas as ocorrências da linha, não só a primeira). O parágrafo seguinte descrevia corretamente o comportamento, só usava o nome errado — ajustei os dois.
- **`exemplos.md`**: também havia um espaço não-quebrável no lugar do `~` em "colocar no seu  /.vimrc", herdado da transcrição.