### PR TITLE
Corrige comandos incorretos do capítulo 7

### DIFF
--- a/docs/capitulo_7/alternando_entre_buffers_de_arquivo.md
+++ b/docs/capitulo_7/alternando_entre_buffers_de_arquivo.md
@@ -16,8 +16,8 @@ Para trocar a visualização do Buffer atual pode-se usar:
 
 | Comando | Descrição |
 |---------|-----------|
-| `:buffer#` | Altera para o buffer anterior |
-| `:b2` | Altera para o buffer cujo a chave é 2 |
+| `:buffer #` | Altera para o buffer alternativo (o editado anteriormente) |
+| `:b2` | Altera para o buffer cuja chave é 2 |
 
 Para os que preferem atalhos para alternar entre os buffers, é possível
 utilizar ‘Ctrl-6’ que tem o mesmo funcionamento do comando `:b#`

--- a/docs/capitulo_7/file_explorer.md
+++ b/docs/capitulo_7/file_explorer.md
@@ -7,11 +7,11 @@ Para abrir o gerenciador de arquivos do Vim use:
 :Vex ............ abre o file explorer verticalmente
 :Sex ............ abre o file explorer em nova janela
 :Tex ............ abre o file explorer em nova aba
-:E .............. abre o file explorer na janela atual
+:Ex ............. abre o file explorer na janela atual
 após abrir chame a ajuda <F1>
 ```
-Para abrir o arquivo sob o cursor em nova janela coloque a linha abaixo
-no seu `~/.vimrc`
+O `:Vex` abre a janela à esquerda. Para que ela abra à direita, coloque a
+linha abaixo no seu `~/.vimrc`
 ```
 let g:netrw_altv = 1
 ```

--- a/docs/capitulo_7/modos_de_divisao_da_janela.md
+++ b/docs/capitulo_7/modos_de_divisao_da_janela.md
@@ -23,13 +23,19 @@ Enquanto os comandos referentes a *tab* deixam a janela
 inteira disponível para o texto e apenas cria uma pequena aba na parte
 superior, o comando *split* literalmente divide a tela atual
 em duas para visualização simultânea dos “buffers” (seja ele o mesmo ou
-outro diferente). Esse é o split padrão do Vim mas pode ser alterado
-facilmente colocando a linha abaixo no seu `~/.vimrc`:
+outro diferente). O comando é `:split` (ou `:sp`), e por padrão a nova
+janela aparece acima da atual. Para que ela apareça abaixo, coloque no
+seu `~/.vimrc`:
 ```
-:set splitright .... split padrão para vertical
+:set splitbelow .... a janela nova abre abaixo da atual
 ```
 ### Utilizando split vertical
 
 O split vertical funciona da mesma maneira que o split horizontal, sendo
 a única diferença o modo como a tela é dividida, pois nesse caso a tela
-é dividida verticalmente.
+é dividida verticalmente. O comando é `:vsplit` (ou `:vs`), e por padrão
+a nova janela aparece à esquerda da atual. Para que ela apareça à
+direita:
+```
+:set splitright .... a janela nova abre à direita da atual
+```


### PR DESCRIPTION
Parte da revisão dos comandos Vim do livro. Este MR trata apenas do capítulo 7.

## Correções

| Arquivo | Antes | Depois |
|---|---|---|
| `modos_de_divisao_da_janela.md` | `:set splitright` = "split padrão para vertical" | `splitbelow` na seção horizontal, `splitright` na vertical, ambos descritos pelo que fazem |
| `file_explorer.md` | `let g:netrw_altv = 1` = "abre o arquivo sob o cursor em nova janela" | "faz o `:Vex` abrir à direita" |
| `file_explorer.md` | `:E` | `:Ex` |
| `alternando_entre_buffers_de_arquivo.md` | `:buffer#` | `:buffer #` |

## Detalhes

- **`splitright`**: não existe opção que transforme `:split` em `:vsplit`. O que `splitright` faz é escolher o lado em que uma divisão **vertical** abre. Como a linha estava na seção de split horizontal, o leitor era levado a crer que mudava o padrão do capítulo inteiro. Reorganizei: `splitbelow` ficou na seção horizontal, `splitright` na vertical. Aproveitei para nomear `:split`/`:sp` e `:vsplit`/`:vs`, que o capítulo mencionava só de passagem.
- **`netrw_altv`**: descrição sem relação com a opção. Ela controla o lado em que o netrw abre a divisão vertical — o análogo de `splitright` para o explorer, o que casa bem com o `:Vex` da linha anterior.
- **`:E`**: com o netrw carregado junto de outros comandos iniciados por E, o Vim responde `E464: Ambiguous use of user-defined command`. `:Ex` é a abreviação documentada de `:Explore`.
- **`:buffer#`**: sem o espaço o Vim tenta interpretar `buffer#` como nome. Também corrigi "cujo a chave" para "cuja chave" na linha seguinte.