### PR TITLE
Corrige comandos incorretos do capítulo 8

### DIFF
--- a/docs/capitulo_8/gravando_comandos.md
+++ b/docs/capitulo_8/gravando_comandos.md
@@ -32,10 +32,9 @@ no registrador ‘a’ até que seja concluído com o comando `<Esc>q` novamente
 | `I` | entra no modo de inserção no começo da linha |
 | `#include "` | insere #include " |
 | `<Esc>` | sai do modo de inserção |
-| `A"` | insere o último caractere |
+| `A"` | acrescenta uma aspa no final da linha |
 | `<Esc>` | sai do modo de inserção |
 | `j` | desce uma linha |
-| `<Esc>` | sai do modo de inserção |
 | `q` | para a gravação da macro |
 
 Agora só é preciso posicionar o cursor na primeira letra de uma linha

--- a/docs/capitulo_8/repetindo_comandos.md
+++ b/docs/capitulo_8/repetindo_comandos.md
@@ -1,4 +1,8 @@
 ```
-:@
+:@:
 ```
-O atalho acima repete o último comando no próprio modo de comandos.
+O comando acima repete o último comando executado no modo de comandos.
+Em modo normal, o equivalente é:
+```
+@:
+```


### PR DESCRIPTION
Parte da revisão dos comandos Vim do livro. Este MR trata apenas do capítulo 8.

## Correções

| Arquivo | Antes | Depois |
|---|---|---|
| `repetindo_comandos.md` | `:@` | `:@:` (e `@:` em modo normal) |
| `gravando_comandos.md` | `A"` = "insere o último caractere" | "acrescenta uma aspa no final da linha" |
| `gravando_comandos.md` | `<Esc>` sobrando após o `j` | linha removida |

## Detalhes

- **`:@`**: o comando pede um registrador (`:@a`, `:@b`, ...). Para repetir a última linha de comando o registrador é o `:`, daí `:@:`. Incluí também o `@:` de modo normal, que é a forma mais usada e já aparece no capítulo 1 ("Alguns atalhos úteis").
- **`A"`**: a descrição não dizia o que o comando faz. No exemplo, ele fecha as aspas de `#include "stdio.h`, acrescentando a aspa final.
- **`<Esc>` sobrando**: a tabela listava um `<Esc>` "sai do modo de inserção" logo depois do `j`, mas o `j` já é executado em modo normal — não há modo de inserção do qual sair. Seguir a tabela ao pé da letra gravava uma tecla a mais na macro.