### PR TITLE
Corrige comandos incorretos do capítulo 9

### DIFF
--- a/docs/capitulo_9/calculadora_cientifica_com_o_vim.md
+++ b/docs/capitulo_9/calculadora_cientifica_com_o_vim.md
@@ -8,11 +8,12 @@ GNU/Linux, ou uma linguagem de programação como *Python* ou
 *Ruby*, veremos como habilitar a calculadora usando o
 *Python*. Obviamente esta linguagem de programação deve
 estar instalada no sistema em que se deseja usar seus recursos. Deve-se
-testar se a versão do Vim tem suporte ao Python `:version`, em seguida
-colocam-se os mapeamentos no `.vimrc`.
+testar se a versão do Vim tem suporte ao Python — procure por `+python3`
+na saída de `:version` — em seguida colocam-se os mapeamentos no
+`.vimrc`.
 ```
-:command! -nargs=+ Calc :py print <args>
-:py from math import *
+:command! -nargs=+ Calc :py3 print(<args>)
+:py3 from math import *
 ```
 Feito isto pode-se usar o comando `:Calc` como visto
 abaixo:
@@ -21,6 +22,6 @@ abaixo:
 :Calc cos(30)
 :Calc pow(5,3)
 :Calc 10.0/3
-:Calc sum(xrange(1,101))
+:Calc sum(range(1,101))
 :Calc [x**2 for x in range(10)] 
 ```

--- a/docs/capitulo_9/editando_comandos_longos_no_linux.md
+++ b/docs/capitulo_9/editando_comandos_longos_no_linux.md
@@ -13,7 +13,7 @@ no terminal, para facilitar esta tarefa pode-se seguir estes passos:
     export VISUAL=vim
     ```
 
-2.  No terminal usar a combinação de teclas `Ctrl-x-e`.
+2.  No terminal usar a combinação de teclas `Ctrl-x Ctrl-e`.
     Esta combinação de teclas abre o editor padrão do sistema onde se
     deve digitar o comando longo, ao sair do editor o terminal executa o
     comando editado.

--- a/docs/capitulo_9/editando_saidas_do_shell.md
+++ b/docs/capitulo_9/editando_saidas_do_shell.md
@@ -32,5 +32,5 @@ comando `!!` corresponde ao último comando, e neste caso a saída
 corresponde a uma lista de arquivos que contém o padrão a ser editado
 faz-se:
 ```
-vim ${!!}
+vim $(!!)
 ```

--- a/docs/capitulo_9/grep.md
+++ b/docs/capitulo_9/grep.md
@@ -2,7 +2,7 @@ Do mesmo jeito que você usa grep na sua linha de comando
 você pode usar o grep interno do Vim. Exatamente do mesmo
 jeito:
 ```
-:grep <caminho> <padrão> <opções>
+:grep <opções> <padrão> <caminho>
 ```
 Use a janela de *quickfix*[^1] aqui também para exibir os
 resultados do grep e poder ir diretamente a eles.


### PR DESCRIPTION
Parte da revisão dos comandos Vim do livro. Este MR trata apenas do capítulo 9.

## Correções

| Arquivo | Antes | Depois |
|---|---|---|
| `grep.md` | `:grep <caminho> <padrão> <opções>` | `:grep <opções> <padrão> <caminho>` |
| `calculadora_cientifica_com_o_vim.md` | `:py print <args>` | `:py3 print(<args>)` |
| `calculadora_cientifica_com_o_vim.md` | `sum(xrange(1,101))` | `sum(range(1,101))` |
| `editando_saidas_do_shell.md` | `vim ${!!}` | `vim $(!!)` |
| `editando_comandos_longos_no_linux.md` | `Ctrl-x-e` | `Ctrl-x Ctrl-e` |

## Detalhes

- **`:grep`**: repassa os argumentos ao `grep` do sistema, que espera as opções primeiro, depois o padrão e por fim os arquivos. Como estava, o caminho seria tomado como padrão de busca.
- **Calculadora científica**: `print x` sem parênteses e `xrange` são Python 2, removido do Vim junto com o `+python`. Verifiquei a versão corrigida rodando de fato:

  ```
  $ vim -es -u NONE -c 'py3 from math import *' \
        -c 'command! -nargs=+ Calc :py3 print(<args>)' \
        -c 'Calc pow(5,3)' -c 'Calc sum(range(1,101))' ...
  125.0
  5050
  ```

  Ajustei também a instrução de checagem: o que se procura em `:version` é `+python3`.
- **`${!!}`**: em bash isso é expansão indireta da variável `!`, não substituição de comando. O texto descreve exatamente o comportamento de `$(!!)`.
- **`Ctrl-x-e`**: o *binding* do bash (`edit-and-execute-command`) é `C-x C-e`. Escrito com um hífen só, sugere que o `e` seja pressionado sozinho.