### PR TITLE
Corrige nomes de comandos corrompidos no capítulo 10

### DIFF
--- a/docs/capitulo_10/habilitando_a_verificacao_ortografica.md
+++ b/docs/capitulo_10/habilitando_a_verificacao_ortografica.md
@@ -5,7 +5,7 @@ title: Habilitando a verificação ortográfica
 A verificação ortográfica atua em uma linguagem (dicionário) por vez,
 portanto, sua efetiva habilitação depende da especificação desta
 linguagem. Por exemplo, para habilitar no arquivo em edição a
-verificação ortográfica na língua portuguesa (*pt*is_active),
+verificação ortográfica na língua portuguesa (`pt`),
 assumindo-se a existência do dicionário em questão:
 ```
 :setlocal spell spelllang=pt
@@ -14,11 +14,11 @@ ou de forma abreviada:
 ```
 :setl spell spl=pt
 ```
-Trocando-se setlocalis_active (setlis_active) por apenas
-setis_active (seis_active) faz com que o comando tenha efeito
+Trocando-se `setlocal` (`setl`) por apenas
+`set` (`se`) faz com que o comando tenha efeito
 global, isto é, todos os arquivos da sessão corrente do Vim estariam sob
 efeito da verificação ortográfica e do mesmo dicionário (no caso o
-ptis_active).
+`pt`).
 
 A desabilitação da verificação dá-se digitando:
 ```
@@ -26,7 +26,7 @@ A desabilitação da verificação dá-se digitando:
 :set nospell            (efeito global)
 ```
 Caso queira-se apenas alterar o dicionário de verificação ortográfica,
-suponha para a língua inglesa (enis_active), basta:
+suponha para a língua inglesa (`en`), basta:
 ```
 :setlocal spelllang=en
 :set spelllang=en       (efeito global)
@@ -38,7 +38,7 @@ habilitação da verificação ortográfica sempre quando desejada. Seria
 conveniente se o Vim habilitasse automaticamente a verificação para
 aqueles tipos de arquivos que comumente fazem uso da verificação
 ortográfica, como por exemplo arquivos “texto”. Isto é possível
-editando-se o arquivo de configuração do Vim .vimrc(veja [Como Editar Preferências no Vim](../capitulo_12/como_editar_preferencias_no_vim.md)) e incluindo as seguintes linhas:
+editando-se o arquivo de configuração do Vim `.vimrc` (veja [Como Editar Preferências no Vim](../capitulo_12/como_editar_preferencias_no_vim.md)) e incluindo as seguintes linhas:
 ```
 autocmd Filetype text setl spell spl=pt
 autocmd BufNewFile,BufRead *.txt setl spell spl=pt


### PR DESCRIPTION
Parte da revisão dos comandos Vim do livro. Este MR trata apenas do capítulo 10.

## O problema

A página "Habilitando a verificação ortográfica" tinha o sufixo `is_active` colado em cinco pontos, resíduo da transcrição do original. O trecho mais afetado é justamente o que explica a diferença entre efeito local e global:

> Trocando-se setlocalis_active (setlis_active) por apenas setis_active (seis_active) faz com que o comando tenha efeito global

## Correções

| Antes | Depois |
|---|---|
| `(*pt*is_active)` | `` (`pt`) `` |
| `setlocalis_active (setlis_active)` | `` `setlocal` (`setl`) `` |
| `setis_active (seis_active)` | `` `set` (`se`) `` |
| `(no caso o ptis_active)` | `` (no caso o `pt`) `` |
| `(enis_active)` | `` (`en`) `` |

Como o sufixo aparecia sempre onde o original marcava um nome de comando, aproveitei para formatá-los como código, ficando coerente com os blocos logo abaixo (`:setlocal spell spelllang=pt` / `:setl spell spl=pt`).

Também corrigi `.vimrc(veja` para `` `.vimrc` (veja ``, que estava sem o espaço antes do parêntese.

Confirmado que não sobrou nenhuma ocorrência em todo o livro:

```
$ grep -rn "is_active" docs/
Nenhuma ocorrência de is_active restante no livro
```