### PR TITLE
Corrige comandos e opções do viminfo no capítulo 11

### DIFF
--- a/docs/capitulo_11/restaurando_sessoes.md
+++ b/docs/capitulo_11/restaurando_sessoes.md
@@ -20,7 +20,7 @@ Podemos fazer mapeamentos para atualizar a sessão atual e exibir
 detalhes da mesma:
 ```
 "mapeamento para gravar sessão
-nmap <F4> :wa<Bar>exe "mksession! " . v:this_session<CR>:so ~/sessions/
+nmap <F4> :wa<Bar>exe "mksession! " . v:this_session<CR>
 
 "mapeamento para exibir a sessão ativa
 map <s-F4> <esc>:echo v:this_session<cr>

--- a/docs/capitulo_11/viminfo.md
+++ b/docs/capitulo_11/viminfo.md
@@ -19,46 +19,21 @@ ser usada para memorizar estas informações.
 -   Variáveis globais
 
 Deve-se colocar no arquivo de configuração algo como:
+```
+set viminfo=%,'50,\"100,/100,:100,n
+```
+Algumas opções da diretiva viminfo:
 
-    set viminfo=%,'50,\"100,/100,:100,n
-
-Algumas opões da diretiva viminfo:
-
-!
-
-:   Quando incluído salva e restaura variáveis globais (variáveis com
-    letra maiúscula) e que não contém letras em minúsculo como
-    MANTENHAISTO.
-
-"
-
-:   Número máximo de linhas salvas para cada registrador.
-
-%
-
-:   Quando incluído salva e restaura a lista de *buffers*.
-    Caso o Vim seja iniciado com um nome como argumento, a lista de
-    *buffers* não é restaurada. *Buffers* sem
-    nome e *buffers* de ajuda não são armazenados no
-    viminfo.
-
-’
-
-:   Número máximo de arquivos recém editados.
-
-/
-
-:   Máximo de itens do histórico de buscas.
-
-:
-
-:   Máximo de itens do histórico da linha de comando
-
-\<
-
-:   Número máximo de linhas salvas por cada registrador, se zero os
-    registradores não serão salvos. Quando não incluído, todas as linhas são
-    salvas.
+| Opção | Descrição |
+|-------|-----------|
+| `!` | Quando incluído salva e restaura variáveis globais (variáveis com letra maiúscula) e que não contém letras em minúsculo como MANTENHAISTO. |
+| `"` | Número máximo de linhas salvas para cada registrador. |
+| `%` | Quando incluído salva e restaura a lista de *buffers*. Caso o Vim seja iniciado com um nome como argumento, a lista de *buffers* não é restaurada. *Buffers* sem nome e *buffers* de ajuda não são armazenados no viminfo. |
+| `'` | Número máximo de arquivos recém editados para os quais as marcas são lembradas. |
+| `/` | Máximo de itens do histórico de buscas. |
+| `:` | Máximo de itens do histórico da linha de comando. |
+| `<` | Número máximo de linhas salvas por cada registrador, se zero os registradores não serão salvos. Quando não incluído, todas as linhas são salvas. |
+| `n` | Nome do arquivo viminfo a ser usado. |
 
 Para ver mais opções sobre o arquivo ‘viminfo’ leia
 ‘:h viminfo’. Pode-se também usar um arquivo de “Sessão”. A


### PR DESCRIPTION
Parte da revisão dos comandos Vim do livro. Este MR trata apenas do capítulo 11.

## Correções

| Arquivo | Antes | Depois |
|---|---|---|
| `restaurando_sessoes.md` | `nmap <F4> ...<CR>:so ~/sessions/` | `nmap <F4> ...<CR>` |
| `viminfo.md` | opção `’` | opção `'` |
| `viminfo.md` | opção `\<` | opção `<` |
| `viminfo.md` | lista de definição | tabela |

## Detalhes

- **`:so ~/sessions/`**: sobrava no fim do mapeamento, sem nome de arquivo e sem `<CR>`. O comentário logo acima diz "mapeamento para gravar sessão", e a gravação já está completa em `:wa<Bar>exe "mksession! " . v:this_session<CR>`. Do jeito que estava, ao pressionar `<F4>` a sessão era gravada mas o Vim ficava com um `:so ~/sessions/` pendurado na linha de comando.
- **Opções do viminfo**: `’` é a aspa tipográfica, não a apóstrofe que o Vim espera; e `\<` tinha uma barra invertida de escape do formato original. Quem copiasse essas opções para o `set viminfo=` receberia erro.
- **Lista de definição → tabela**: a página usava a sintaxe `termo` / `:   descrição`, que depende da extensão `def_list`. Ela não está habilitada no `zensical.toml` (só `admonition`, `footnotes`, `md_in_html` e as `pymdownx`), então a página renderizava como parágrafos avulsos com dois-pontos soltos. Converti para tabela, seguindo a convenção adotada no restante do livro.
- Aproveitei para incluir a opção `n` (nome do arquivo viminfo), que já aparecia no exemplo `set viminfo=%,'50,\"100,/100,:100,n` mas não estava descrita, e para corrigir "opões" → "opções".