### PR TITLE
Corrige comandos incorretos do capítulo 12

### DIFF
--- a/docs/capitulo_12/ajustando_paragrafos_em_modo_normal.md
+++ b/docs/capitulo_12/ajustando_paragrafos_em_modo_normal.md
@@ -3,8 +3,9 @@ title: Ajustando parágrafos em modo normal
 ---
 
 O comando `gqap` ajusta o parágrafo atual em modo normal. Usando a
-opção *:set nojoinspaces* o vim colocará dois espaços após
-o ponto final ao se ajustar os parágrafos.
+opção *:set joinspaces* o vim colocará dois espaços após
+o ponto final ao se ajustar os parágrafos; com *:set nojoinspaces*,
+que é o padrão, ele coloca apenas um.
 
 geralmente usamos `^I` para representar uma tabulação `<Tab>`, e `$`
 para indicar o fim de linha. Mas é possível customizar essas opções.
@@ -21,12 +22,18 @@ set listchars=key:string,key:string
  seguido por {char2}
 
  - trail:{char}
- Esse caracter representa os espaços em branco.
+ Esse caracter representa os espaços em branco no
+ fim da linha
 
  - extends:{char}
- Esse caracter representa o início do fim da linha
- sem quebrá-la
- Está opção funciona com a opção nowrap habilitada
+ Esse caracter é mostrado na última coluna quando a
+ linha continua além da borda direita da tela
+ Esta opção funciona com a opção nowrap habilitada
+
+ - precedes:{char}
+ Esse caracter é mostrado na primeira coluna quando
+ há conteúdo antes do início visível da linha
+ Esta opção funciona com a opção nowrap habilitada
 
 "exemplo 1:
 "set listchars=tab:>-,trail:.,eol:#,extends:@
@@ -35,9 +42,6 @@ set listchars=key:string,key:string
 "set listchars=tab:>-
 
 "exemplo 3:
-"set listchars=tab:>-
-
-"exemplo 4:
 set nowrap    "Essa opção desabilita a quebra de linha
-"set listchars=extends:+
+"set listchars=extends:+,precedes:<
 ```

--- a/docs/capitulo_12/como_adicionar_o_python_ao_path_do_vim.md
+++ b/docs/capitulo_12/como_adicionar_o_python_ao_path_do_vim.md
@@ -5,20 +5,21 @@ title: Como adicionar o Python ao path do Vim?
 Coloque o seguinte
 [script](http://vim.wikia.com/wiki/Automatically_add_Python_paths_to_Vim_path)
 em:
-```
- * ~/.vim/after/ftplugin/python.vim    (on Unix systems)
- %* $HOME/vimfiles/after/ftplugin/python.vim    (on Windows systems)
 
- python << EOF
- import os
- import sys
- import vim
- for p in sys.path:
-     # Add each directory in sys.path, if it exists.
-     if os.path.isdir(p):
-         # Command `set' needs backslash before each space.
-         vim.command(r``s'' % (p.replace(`` '', r`` '')))
- EOF
+-   `~/.vim/after/ftplugin/python.vim` (em sistemas Unix)
+-   `$HOME/vimfiles/after/ftplugin/python.vim` (no Windows)
+
+```VimL
+python3 << EOF
+import os
+import sys
+import vim
+for p in sys.path:
+    # Add each directory in sys.path, if it exists.
+    if os.path.isdir(p):
+        # Command 'set' needs backslash before each space.
+        vim.command(r"set path+=%s" % (p.replace(" ", r"\ ")))
+EOF
 ```
 Isto lhe permite usar *gf* ou *Ctrl-w Ctrl-F*
 para abrir um arquivo sob o cursor

--- a/docs/capitulo_12/complementacao_com_tab.md
+++ b/docs/capitulo_12/complementacao_com_tab.md
@@ -13,16 +13,16 @@ set complete=.,w,k
 "usa o tab em modo de inserção para completar palavras
 
 function! InsertTabWrapper(direction)
-   let col = col(``.'') - 1
-   if !col || getline(``.'')[col - 1] !~ '\k'
-      return ``>''
-   elseif ``d'' == a:direction
-      return ``>''
+   let col = col('.') - 1
+   if !col || getline('.')[col - 1] !~ '\k'
+      return "\<tab>"
+   elseif "backward" == a:direction
+      return "\<c-p>"
    else
-      return ``>''
+      return "\<c-n>"
    endif
 endfunction
 
-inoremap <tab> <c-r>=InsertTabWrapper (``d'')<cr>
-inoremap <s-tab> <c-r>=InsertTabWrapper (``d'')<cr>
+inoremap <tab> <c-r>=InsertTabWrapper ("forward")<cr>
+inoremap <s-tab> <c-r>=InsertTabWrapper ("backward")<cr>
 ```

--- a/docs/capitulo_12/definindo_registros_previamente.md
+++ b/docs/capitulo_12/definindo_registros_previamente.md
@@ -8,7 +8,7 @@ Para executar o registro `s` definido acima faça:
 ```
 O Vim colocará no comando
 ```
-:sort -u
+:sort u
 ```
 Bastando pressionar `<Enter>`. Observação: Este registro prévio pode
 ficar no `vimrc` ou ser digitado em comando “:”

--- a/docs/capitulo_12/efetivacao_das_alteracoes_no_vimrc.md
+++ b/docs/capitulo_12/efetivacao_das_alteracoes_no_vimrc.md
@@ -8,6 +8,6 @@ configuração seja instruído explicitamente:
 
 | Comando | Descrição |
 |---------|-----------|
-| `:source ~/vimrc` | se estiver no GNU/Linux |
+| `:source ~/.vimrc` | se estiver no GNU/Linux |
 | `:source ~/_vimrc` | caso use o Windows |
 | `:so arquivo` | `so' é uma abreviação de `source' |

--- a/docs/capitulo_12/exemplo_de_menu.md
+++ b/docs/capitulo_12/exemplo_de_menu.md
@@ -13,8 +13,9 @@ menu T&emas.fonte.Monaco :set gfn=monaco:h9<CR>
 menu T&emas.fonte.Crisp :set anti gfn=Crisp:h12<CR>
 menu T&emas.fonte.Liberation\ Mono :set gfn=Liberation\ Mono:h10<CR>
 ```
-O comando “*:update*” Atualiza o menu recém modificado.
-Quando o comando “*:amenu*” É usado sem nenhum argumento o
+Para que as alterações nos menus passem a valer, recarregue o arquivo de
+configuração com “*:source ~/.vimrc*”.
+Quando o comando “*:amenu*” é usado sem nenhum argumento o
 Vim mostra os menus definidos atualmente. Para listar todas as opções de
 menu para `Plugin` por exemplo digita-se no modo de comandos
 “*:amenu Plugin*”.

--- a/docs/capitulo_12/funcoes.md
+++ b/docs/capitulo_12/funcoes.md
@@ -15,7 +15,7 @@ title: Funções
  inoremap <C-j> <Esc>:call search(BC_GetChar(), "W")<cr>a
  " Function for the above
  function! BC_AddChar(schar)
-	if exists("k")
+	if exists("b:robstack")
 		let b:robstack = b:robstack . a:schar
 	else
 		let b:robstack = a:schar
@@ -26,9 +26,11 @@ title: Funções
 	let b:robstack = strpart(b:robstack, 0, strlen(b:robstack)-1)
 	return l:char
  endfunction
+```
 
-'''Outra opção para fechamento de parênteses'''
+Outra opção para fechamento de parênteses:
 
+```VimL
  " Fechamento automático de parênteses
  imap { {}<left>
  imap ( ()<left>

--- a/docs/capitulo_12/mapeamentos.md
+++ b/docs/capitulo_12/mapeamentos.md
@@ -15,10 +15,9 @@ tecla ....... tecla mapeada
 <leader> .... normalmente \
 <bar> ....... | pipe
 <cword> ..... palavra sob o cursor
+<cWORD> ..... palavra sob o cursor, delimitada por espaços
 <cfile> ..... arquivo sob o cursor
-<cfile> ..... arquivo sob o cursor sem extensão
-<sfile> ..... conteúdo do arquivo sob o cursor
-<left> ...... salta um caractere para esquerda
+<sfile> ..... arquivo sendo carregado com :source
 <up> ........ equivale clicar em `seta acima'
 <m-f4> ...... a tecla alt (m) mais a tecla f4
 <c-f> ....... Ctrl-f
@@ -31,7 +30,7 @@ determinada operação e a mesma tecla pode desempenhar outra função
 qualquer em modo de inserção ou comando, veja:
 ```VimL
 " mostra o nome do arquivo com o caminho
-map <F2> :echo expand("%:p")
+map <F2> :echo expand("%:p")<cr>
 " insere um texto qualquer
 imap <F2> Nome de uma pessoa
 ```
@@ -66,10 +65,12 @@ inserir caracteres reservados do HTML usando uma barra invertida para
 proteger os mesmos, o Vim substituirá os “barra alguma coisa” pelo
 caractere correspondente.
 ```VimL
-inoremap \&amp; &amp;amp;
-inoremap \&lt; &amp;lt;
-inoremap \&gt; &amp;gt;
-inoremap \. &amp;middot;
+inoremap \& &amp;
+" <lt> representa o caractere `<', que sozinho iniciaria
+" o nome de uma tecla especial
+inoremap \<lt> &lt;
+inoremap \> &gt;
+inoremap \. &middot;
 ```
 O termo **inoremap** significa: em modo de inserção não
 remapear, ou seja ele mapeia o atalho e não permite que o mesmo seja
@@ -100,7 +101,7 @@ teclas `Shift-F11` limpe o “registrador” de buscas
 
 ### Destacar palavra sob o cursor
 ```VimL
-nmap <s-f> :let @/=">"<CR>
+nmap <s-f> :let @/=expand("<cword>")<CR>
 ```
 O atalho acima `s-f` corresponde a `Shift-f`.
 
@@ -126,26 +127,25 @@ substituídas por uma só linha em branco, vejamos como funciona:
 | Comando | Descrição |
 |---------|-----------|
 | `map` | mapear |
-| `,d` | atalho que quermos |
-| `<Esc>` | se estive em modo de inserção sai |
+| `,d` | atalho que queremos |
+| `<Esc>` | se estiver em modo de inserção, sai |
 | `:` | em modo de comando |
 | `%` | em todo o arquivo |
 | `s` | substitua |
+| `^` | começo de linha |
 | `\n` | quebra de linha |
-| `{2,}` | duas ou mais vezes |
+| `\{2,}` | duas ou mais vezes |
 | `\r` | trocado por \r Enter |
 | `g` | globalmente |
 | `<cr>` | confirmação do comando |
 
-As barras invertidas podem não ser usadas se o seu Vim estiver com a
-opção **magic** habilitada
+As barras invertidas dos quantificadores podem ser dispensadas usando o
+modo *very magic*, indicado por `\v` no início do padrão:
 ```
-:set magic
+map ,d :%s/\v(^\n{2,})/\r/g<cr>
 ```
-Por acaso este é um padrão portanto tente usar assim pra ver se funciona
-```
-map ,d :%s/\n{2,}/\r/g<cr>
-```
+Note que a opção **magic**, habilitada por padrão, não é suficiente para
+isso: com ela `\{2,}` ainda precisa da barra invertida.
 ### Mapeamento para Calcular Expressões
 
 Os mapeamentos abaixo exibem o resultado das quatro operações básicas

--- a/docs/capitulo_12/outros_mapeamentos.md
+++ b/docs/capitulo_12/outros_mapeamentos.md
@@ -11,9 +11,9 @@ Explicando com detalhes
 | `\+` | uma ou mais vezes |
 | `$` | no final da linha |
 | `\|` | ou |
-| ```` ''`` | espaço (veja imagem acima) |
+| ` ` | um espaço literal |
 | `\+` | uma ou mais vezes |
-| `\ze` | até o fim |
+| `\ze` | marca o fim da correspondência (não entra no destaque) |
 | `\t` | tabulação |
 
 Portanto a expressão regular acima localizará espaços ou tabulações no

--- a/docs/capitulo_12/set.md
+++ b/docs/capitulo_12/set.md
@@ -20,10 +20,10 @@ set sw=4 ................. "simplificação de `shiftwidth'
 syntax on ................ "habilita cores
 syn on ................... "simplificação de `syntax'
 colorscheme tema ......... "esquema de cores `syntax highlight'
-autochdir ................ "configura o diretório de trabalho
+set autochdir ............ "configura o diretório de trabalho
 set hls .................. "destaca com cores os termos procurados
 set incsearch ............ "habilita a busca incremental
-set ai ................... "auto identação
+set ai ................... "auto indentação
 set aw ................... "salva automaticamente ao trocar de
                        `buffer'
 set ignorecase ........... "ignora maiúsculas e minúsculas nas
@@ -41,7 +41,7 @@ set bex=.backup .......... "simplificação de backupext
 set backupdir=~/.backup,./ "diretório(s) para arquivos de backup
 set bdir ................. "simplificação de `backupdir'
 set nobackup ............. "evita a criação de arquivos de backup
-ste nobk ................. "simplificação de `nobackup'
+set nobk ................. "simplificação de `nobackup'
 set cursorline ........... "abreviação de cursor line (destaca
                        linha  atual)
 set cul .................. "simplificação de `cursorline'
@@ -55,5 +55,5 @@ Se ao iniciar o vim obtivermos mensagens de erros e houver dúvida se o
 erro é no vim ou em sua configuração, pode-se inicia-lo sem que o mesmo
 carregue o arquivo `.vimrc`.
 ```
-:vim -u NONE
+vim -u NONE
 ```


### PR DESCRIPTION
Parte da revisão dos comandos Vim do livro. Este MR trata apenas do capítulo 12, o mais afetado.

## Correções

| Arquivo | Antes | Depois |
|---|---|---|
| `efetivacao_das_alteracoes_no_vimrc.md` | `:source ~/vimrc` | `:source ~/.vimrc` |
| `set.md` | `:vim -u NONE` | `vim -u NONE` |
| `set.md` | `ste nobk`, `autochdir`, "auto identação" | `set nobk`, `set autochdir`, "auto indentação" |
| `definindo_registros_previamente.md` | `:sort -u` | `:sort u` |
| `ajustando_paragrafos_em_modo_normal.md` | `nojoinspaces` põe dois espaços | `joinspaces` põe dois, `nojoinspaces` põe um |
| `ajustando_paragrafos_em_modo_normal.md` | `extends` = "início do fim da linha" | descrição correta + `precedes` |
| `mapeamentos.md` | `inoremap \&amp; &amp;amp;` | `inoremap \& &amp;` |
| `mapeamentos.md` | `nmap <s-f> :let @/=">"<CR>` | `:let @/=expand("<cword>")<CR>` |
| `mapeamentos.md` | `<cfile>` duplicado, `<sfile>` = "conteúdo do arquivo" | `<cWORD>` e `<sfile>` corretos |
| `mapeamentos.md` | `map <F2> :echo expand("%:p")` | faltava o `<cr>` |
| `mapeamentos.md` | "barras podem não ser usadas com **magic**" | modo *very magic* (`\v`) |
| `outros_mapeamentos.md` | `\ze` = "até o fim" | "marca o fim da correspondência" |
| `exemplo_de_menu.md` | "`:update` atualiza o menu" | `:source ~/.vimrc` |
| `complementacao_com_tab.md` | função com `` ``>'' `` nos três ramos | `"\<tab>"`, `"\<c-p>"`, `"\<c-n>"` |
| `como_adicionar_o_python_ao_path_do_vim.md` | `vim.command(r``s'' % ...)` | `vim.command(r"set path+=%s" % ...)` |
| `funcoes.md` | `if exists("k")` | `if exists("b:robstack")` |
| `funcoes.md` | `'''...'''` (MediaWiki) dentro do bloco | texto fora do bloco |

## Verificações executadas

Os trechos reconstruídos foram testados, não só relidos.

**`InsertTabWrapper`** — os três ramos respondem como devem (com palavra sob o cursor):

```
$ vim -es -u NONE /tmp/w.txt -c 'source /tmp/tabwrap.vim' -c 'normal! $' ...
^N     " forward
^P     " backward
```

**Script do path do Python** — popula `path` de fato:

```
path=.,,,~/.pyenv/versions/3.14.6/lib/python3.14,...site-packages
```

**`BC_AddChar`** — com `exists("k")` a pilha nunca acumulava, porque `k` nunca existe. Corrigido, empilha e desempilha:

```
)}     " após dois BC_AddChar
}      " BC_GetChar()
)      " resta na pilha
```

**Mapeamentos HTML** — os quatro registram corretamente:

```
i  \.  * &middot;
i  \>  * &gt;
i  \<  * &lt;
i  \&  * &amp;
```

**Afirmação sobre `magic`** — testei as duas formas sobre o mesmo arquivo com linhas em branco repetidas. Com `\{2,}` as linhas colapsam; sem a barra invertida nada acontece, mesmo com `magic` ligado. O modo que dispensa os escapes é o `\v`, então troquei o exemplo e a explicação.

## Notas

- **`:sort -u`**: o registrador definido logo acima é `:sort u`; o texto dizia que o Vim colocaria `:sort -u` na linha de comando. `-u` não é sintaxe do `:sort` do Vim.
- **`nojoinspaces`**: é o padrão do Vim e insere **um** espaço. A página afirmava o contrário, invertendo o efeito da opção.
- **`<sfile>`**: é o nome do arquivo sendo carregado por `:source`, não "conteúdo do arquivo sob o cursor". A linha duplicada de `<cfile>` ("sem extensão") virou `<cWORD>`, que faltava na lista.
- **Python 2 → 3**: aproveitei para trocar `python << EOF` por `python3 << EOF` no script do path, já que `+python` foi removido das versões atuais.