### PR TITLE
Corrige comandos incorretos do capítulo 14

### DIFF
--- a/docs/capitulo_14/edite_varios_arquivos_de_uma_so_vez.md
+++ b/docs/capitulo_14/edite_varios_arquivos_de_uma_so_vez.md
@@ -8,7 +8,7 @@ exemplo seria abrir dezenas de arquivos HTML e trocar a ocorrência
 sequência de comandos:
 ```
 vim *.html  .................................... abre os arquivos
-:bufdo :%s/bgcolor=`ffffff'/bgcolor=`eeeeee'/g   substituição
+:bufdo %s/bgcolor="ffffff"/bgcolor="eeeeee"/ge  substituição
 :wall       .................................... salva todos
 :qa[ll]     .................................... fecha todos
 ```

--- a/docs/capitulo_14/nao_digite_duas_vezes.md
+++ b/docs/capitulo_14/nao_digite_duas_vezes.md
@@ -29,7 +29,7 @@ Para um trecho muito copiado coloque o seu conteúdo em um registrador:
 "ap  ... cola o registrador `a'
 ```
 Crie abreviações para erros comuns no seu arquivo de configuração
-( /.vimrc):
+(`~/.vimrc`):
 
 ```VimL
 iabbrev teh the

--- a/docs/capitulo_14/use_autocomandos.md
+++ b/docs/capitulo_14/use_autocomandos.md
@@ -17,12 +17,12 @@ tipo html/htm e no caso de arquivos novos
 indicado:
 ```VimL
 augroup html
- au! <--> Remove all html autocommands
+  " Remove todos os autocomandos html
   au!
   au BufNewFile,BufRead *.html,*.shtml,*.htm set ft=html
   au BufNewFile,BufRead,BufEnter  *.html,*.shtml,*.htm so ~/docs/vim/.vimrc-html
   au BufNewFile *.html 0r ~/docs/vim/skel.html
-  au BufNewFile *.html*.shtml,*.htm /body/+  " coloca o cursor após o corpo <body>
+  au BufNewFile *.html,*.shtml,*.htm /body/+  " coloca o cursor após o corpo <body>
   au BufNewFile,BufRead *.html,*.shtml,*.htm set noautoindent
 augroup end
 ```


### PR DESCRIPTION
Parte da revisão dos comandos Vim do livro. Este MR trata apenas do capítulo 14.

## Correções

| Arquivo | Antes | Depois |
|---|---|---|
| `use_autocomandos.md` | `au! <--> Remove all html autocommands` | `" Remove todos os autocomandos html` |
| `use_autocomandos.md` | `au BufNewFile *.html*.shtml,*.htm` | `au BufNewFile *.html,*.shtml,*.htm` |
| `edite_varios_arquivos_de_uma_so_vez.md` | ``:bufdo :%s/bgcolor=`ffffff'/...`` | `:bufdo %s/bgcolor="ffffff"/.../ge` |
| `nao_digite_duas_vezes.md` | `( /.vimrc)` | `` (`~/.vimrc`) `` |

## Detalhes

- **`au! <-->`**: na origem isso era um comentário descrevendo a linha seguinte (`au!`, que limpa os autocomandos do grupo). Ao perder as aspas, virou um `au!` com argumentos inválidos — quem copiasse o bloco receberia erro logo na primeira linha do `augroup`.
- **`*.html*.shtml`**: sem a vírgula, o Vim lê um único padrão `*.html*.shtml` e o autocomando nunca dispara. Todas as outras linhas do mesmo grupo já usavam a lista separada por vírgulas.
- **`:bufdo`**: as aspas tipográficas vieram da transcrição do PDF e não são aspas válidas para o padrão. Também removi os dois-pontos redundantes antes do `%s` e acrescentei a opção `e`, sem a qual o `:bufdo` aborta no primeiro buffer que não contiver o padrão — mesma forma que o capítulo 8 já usa em `usando_o_comando_bufdo.md`.
- **`( /.vimrc)`**: havia um espaço não-quebrável ocupando o lugar do `~`, resíduo da transcrição.