### PR TITLE
Corrige comandos incorretos do capítulo 15

### DIFF
--- a/docs/capitulo_15/o_plugin_project.md
+++ b/docs/capitulo_15/o_plugin_project.md
@@ -23,7 +23,7 @@ Para criar uma entrada (acesso ao plugin) no menu do Gvim colocamos
 a seguinte linha no `vimrc`.
 
 ```
-amenu &Projetos.togle <Plug>ToggleProject<cr>
+amenu &Projetos.toggle <Plug>ToggleProject<cr>
 ```
 
 Pode-se definir um projeto manualmente assim:
@@ -34,6 +34,6 @@ nome=~/docs/ CD=. filter="*.txt" {
 }
 ```
 
-Ao recarregar o Vim pode-se abrir o *Plugin* `:Projetc` e
+Ao recarregar o Vim pode-se abrir o *Plugin* `:Project` e
 pressionar o atalho `\r` para que o mesmo gere um índice dos arquivos
 contidos no caminho indicado.

--- a/docs/capitulo_15/o_plugin_pydiction.md
+++ b/docs/capitulo_15/o_plugin_pydiction.md
@@ -19,7 +19,7 @@ No exemplo abaixo o dicionário é adicionado ao diretório `~/.vim/dict`
 
 ```VimL
 if has("autocmd")
-    autocmd FileType python set complete+=k/.vim/dict/pydiction isk+=.,(
+    autocmd FileType python set complete+=k~/.vim/dict/pydiction isk+=.,(
 endif " has("autocmd")
 ```
 

--- a/docs/capitulo_15/um_wiki_para_o_vim.md
+++ b/docs/capitulo_15/um_wiki_para_o_vim.md
@@ -2,7 +2,7 @@
 title: Um wiki para o Vim
 ---
 
-O "*plugin*" wikipot implementa um wiki para o Vim no qual você define um
+O "*plugin*" potwiki implementa um wiki para o Vim no qual você define um
 "link" com a notação WikiWord, onde um "link" é uma palavra que começa com
 uma letra maiúscula e tem outra letra maiúscula no meio.
 Obtenha o plugin


### PR DESCRIPTION
Parte da revisão dos comandos Vim do livro. Este MR trata apenas do capítulo 15, e encerra a série.

## Correções

| Arquivo | Antes | Depois |
|---|---|---|
| `o_plugin_pydiction.md` | `set complete+=k/.vim/dict/pydiction` | `set complete+=k~/.vim/dict/pydiction` |
| `o_plugin_project.md` | `:Projetc` | `:Project` |
| `o_plugin_project.md` | `amenu &Projetos.togle` | `amenu &Projetos.toggle` |
| `um_wiki_para_o_vim.md` | "o plugin wikipot" | "o plugin potwiki" |

## Detalhes

- **Pydiction**: sem o `~`, o caminho aponta para `/.vim/dict/pydiction`, na raiz do sistema. O texto logo acima do bloco diz "o dicionário é adicionado ao diretório `~/.vim/dict`", então a intenção era o diretório do usuário.
- **`:Projetc`**: letras trocadas. O nome correto já aparecia certo na tabela de comandos do mesmo arquivo, o que tornava a página contraditória.
- **`wikipot`**: o plugin é o **potwiki**, como consta no capítulo 13, que trata dele em detalhe, e no link do próprio parágrafo (`script_id=1018`).