### PR TITLE
Corrige .virmc para .vimrc no capítulo 13

### DIFF
--- a/docs/capitulo_13/uma_wiki_para_o_vim.md
+++ b/docs/capitulo_13/uma_wiki_para_o_vim.md
@@ -18,7 +18,7 @@ define onde ele guardará os arquivos, no meu caso
 ```
 call s:default('home',"~/.wiki/HomePage")
 ```
-Outra forma de indicar a página inicial seria colocar no seu .virmc
+Outra forma de indicar a página inicial seria colocar no seu `.vimrc`
 ```
 let potwiki_home = "$HOME/.wiki/HomePage"
 ```


### PR DESCRIPTION
Erro de digitação em `capitulo_13/uma_wiki_para_o_vim.md`, linha 21: `.virmc` com as letras trocadas.

O trecho indica onde colocar `let potwiki_home = "$HOME/.wiki/HomePage"`, então o nome errado pode confundir quem for seguir o passo.

Aproveitei para formatar como código, ficando coerente com o resto do livro, que sempre marca `.vimrc` assim.

Encontrado ao levantar a issue #50. Não depende dela: aquela trata da duplicação das páginas sobre o potwiki entre os capítulos 13 e 15, e esta correção vale de qualquer forma, seja qual for a decisão sobre unificar ou não as páginas.