### PR TITLE
Converte em tabelas as listas de referência restantes

### DIFF
--- a/docs/capitulo_1/erros_comuns.md
+++ b/docs/capitulo_1/erros_comuns.md
@@ -12,22 +12,24 @@
     digitou ao entrar no modo de inserção. A palavra aparecerá repetida
     na quantidade do número digitado. Assim, se você quiser digitar 10
     vezes `isto é um teste` faça assim:
-```
-<Esc> ........... se assegure de estar em modo normal
-10 .............. quantificador
-i ............... entra no modo de inserção
-isto é um teste <Enter> <Esc>
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `<Esc>` | se assegure de estar em modo normal |
+| `10` | quantificador |
+| `i` | entra no modo de inserção |
+| `isto é um teste <Enter> <Esc>` | digita o texto e volta ao modo normal |
 
 Alguns atalhos úteis…
-```
-Ctrl-O ..... comando do modo normal no modo insert
-i Ctrl-a ... repetir a última inserção
-@: ......... repetir o último comando
-Shift-insert colar texto da área de transferência
-gi ......... modo de inserção no mesmo ponto da última vez
-gv ......... repete seleção visual
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `Ctrl-O` | comando do modo normal no modo insert |
+| `i Ctrl-a` | repetir a última inserção |
+| `@:` | repetir o último comando |
+| `Shift-insert` | colar texto da área de transferência |
+| `gi` | modo de inserção no mesmo ponto da última vez |
+| `gv` | repete seleção visual |
 
 Para saber mais sobre repetição de comandos veja o capítulo
 [Repetição de comandos](../capitulo_8/repeticao_de_comandos.md).

--- a/docs/capitulo_10/comandos_relativos_a_verificacao_ortografica.md
+++ b/docs/capitulo_10/comandos_relativos_a_verificacao_ortografica.md
@@ -42,9 +42,11 @@ cometido na grafia, de forma que o próprio possa corrigi-la sem auxílio
 externo. No entanto, algumas vezes o erro não é evidente, e sugestões
 fornecidas pelo Vim podem ser bastante convenientes. Para listar as
 sugestões para a palavra em questão executa-se:
-```
-z= ..... solicita sugestões ao verificador ortográfico
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `z=` | solicita sugestões ao verificador ortográfico |
+
 Se alguma das sugestões é válida – as mais prováveis estão nas primeiras
 posições – então basta digitar seu prefixo numérico e pressionar
 `<Enter>`. Se nenhuma sugestão for adequada, basta simplesmente
@@ -56,8 +58,9 @@ Por mais completo que um dicionário seja, eventualmente palavras,
 especialmente as de menor abrangência, terão que ser cadastradas a fim
 de aprimorar a exatidão da verificação ortográfica. A manutenção do
 dicionário dá-se pelo cadastramento e retirada de palavras:
-```
-zg ..... adiciona a palavra no dicionário
-zw ..... retira a palavra no dicionário, marcando-a como
-         `desconhecida'
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `zg` | adiciona a palavra no dicionário |
+| `zw` | retira a palavra do dicionário, marcando-a como `desconhecida' |
+

--- a/docs/capitulo_12/autocomandos.md
+++ b/docs/capitulo_12/autocomandos.md
@@ -49,18 +49,21 @@ leva um tempo. Para configurar o vim de forma que ele detecte este tipo
 de erro ao entrar no arquivo:
 ```
 au! VimEnter * match ErrorMsg /^\t\+/
-
-" explicação para o autocomando acima
-au! ............... automaticamente
-VimEnter .......... ao entrar no vim
-* ................. para qualquer tipo de arquivo
-match ErrorMsg .... destaque como erro
-/ ................. inicio de um padrão
-^ ................. começo de linha
-\t ................ tabulação
-\+ ................ uma vez ou mais
-/ ................. fim do padrão de buscas
 ```
+
+Explicação para o autocomando acima:
+
+| Comando | Descrição |
+|---------|-----------|
+| `au!` | automaticamente |
+| `VimEnter` | ao entrar no vim |
+| `*` | para qualquer tipo de arquivo |
+| `match ErrorMsg` | destaque como erro |
+| `/` | inicio de um padrão |
+| `^` | começo de linha |
+| `\t` | tabulação |
+| `\+` | uma vez ou mais |
+| `/` | fim do padrão de buscas |
 Para evitar que este erro se repita, ou seja, que sejam adicionados no
 começo de linha espaços no lugar de tabulações adiciona-se ao \~/.vimrc
 ```

--- a/docs/capitulo_12/criando_um_menu.md
+++ b/docs/capitulo_12/criando_um_menu.md
@@ -5,11 +5,12 @@ favoritos em um menu veja este exemplo
 amenu Ferramentas.ExibirNomeDoTema :echo g:colors_name<cr>
 ```
 O comando acima diz:
-```
-amenu ........................ cria um menu
-Ferramentas.ExibirNomeDoTema . Menu plugin submenu ExibirNomeDoTema
-:echo g:colors_name<cr> ...... exibe o nome do tema atual
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `amenu` | cria um menu |
+| `Ferramentas.ExibirNomeDoTema` | menu Ferramentas, submenu ExibirNomeDoTema |
+| `:echo g:colors_name<cr>` | exibe o nome do tema atual |
 Caso haja espaços no nome a definir você pode fazer assim
 ```
 amenu Ferramentas.Exibir\ nome\ do\ tema :echo g:colors_name<cr>

--- a/docs/capitulo_12/exemplo_de_menu.md
+++ b/docs/capitulo_12/exemplo_de_menu.md
@@ -21,10 +21,12 @@ menu para `Plugin` por exemplo digita-se no modo de comandos
 “*:amenu Plugin*”.
 
 #### Ocultando as barras de ferramentas e menu
-```
-:set guioptions-=m  ........ oculta menus
-:set guioptions-=T  ........ oculta icones
 
-obs: para exibir novamente repita o comando
-substituindo o sinal de menos por mais.
-```
+| Comando | Descrição |
+|---------|-----------|
+| `:set guioptions-=m` | oculta menus |
+| `:set guioptions-=T` | oculta ícones |
+
+Obs: para exibir novamente repita o comando substituindo o sinal de menos
+por mais.
+

--- a/docs/capitulo_12/mapeamentos.md
+++ b/docs/capitulo_12/mapeamentos.md
@@ -3,28 +3,28 @@ depende da criatividade do usuário e do quanto conhece o Vim, com eles
 podemos controlar ações com quaisquer teclas, mas antes temos que saber
 que para criar mapeamentos, precisamos conhecer a maneira de representar
 as teclas e combinações. Alguns exemplos:
-```
-tecla ....... tecla mapeada
 
-<c-x> ....... Ctrl-x
-<left> ...... seta para a esquerda
-<right> ..... seta para a direita
-<c-m-a> ..... Ctrl-Alt-a
-<cr> ........ Enter
-<Esc> ....... Escape
-<leader> .... normalmente \
-<bar> ....... | pipe
-<cword> ..... palavra sob o cursor
-<cWORD> ..... palavra sob o cursor, delimitada por espaços
-<cfile> ..... arquivo sob o cursor
-<sfile> ..... arquivo sendo carregado com :source
-<up> ........ equivale clicar em `seta acima'
-<m-f4> ...... a tecla alt (m) mais a tecla f4
-<c-f> ....... Ctrl-f
-<bs> ........ backspace
-<space> ..... espaço
-<tab> ....... tab
-```
+| Notação | Tecla mapeada |
+|---------|---------------|
+| `<c-x>` | Ctrl-x |
+| `<left>` | seta para a esquerda |
+| `<right>` | seta para a direita |
+| `<c-m-a>` | Ctrl-Alt-a |
+| `<cr>` | Enter |
+| `<Esc>` | Escape |
+| `<leader>` | normalmente \ |
+| `<bar>` | <code>&#124;</code> pipe |
+| `<cword>` | palavra sob o cursor |
+| `<cWORD>` | palavra sob o cursor, delimitada por espaços |
+| `<cfile>` | arquivo sob o cursor |
+| `<sfile>` | arquivo sendo carregado com :source |
+| `<up>` | equivale clicar em `seta acima' |
+| `<m-f4>` | a tecla alt (m) mais a tecla f4 |
+| `<c-f>` | Ctrl-f |
+| `<bs>` | backspace |
+| `<space>` | espaço |
+| `<tab>` | tab |
+
 No Vim podemos mapear uma tecla para o modo normal, realizando
 determinada operação e a mesma tecla pode desempenhar outra função
 qualquer em modo de inserção ou comando, veja:

--- a/docs/capitulo_12/set.md
+++ b/docs/capitulo_12/set.md
@@ -7,50 +7,44 @@ ou digitados como comandos:
 ```
 :set nu
 ```
-```
-set number ............... "mostra numeração de linhas
-set nu ................... "simplificação de `number'
-set showmode ............. "mostra o modo em que estamos
-set showcmd .............. "mostra no status os comandos inseridos
-set tabstop=4 ............ "tamanho das tabulações
-set ts=4 ................. "simplificação de `tabstop'
-set shiftwidth=4 ......... "quantidade de espaços de uma
-                       tabulação
-set sw=4 ................. "simplificação de `shiftwidth'
-syntax on ................ "habilita cores
-syn on ................... "simplificação de `syntax'
-colorscheme tema ......... "esquema de cores `syntax highlight'
-set autochdir ............ "configura o diretório de trabalho
-set hls .................. "destaca com cores os termos procurados
-set incsearch ............ "habilita a busca incremental
-set ai ................... "auto indentação
-set aw ................... "salva automaticamente ao trocar de
-                       `buffer'
-set ignorecase ........... "ignora maiúsculas e minúsculas nas
-                       buscas
-set ic ................... "simplificação de ignorecase
-set smartcase ............ "numa busca em maiúsculo habilita
-                       `case'
-set scs .................. "sinônimo de `smartcase'
-set backup ............... "habilita a criação de arquivos de
-                       backup
-set bk ................... "simplificação de `backup'
-set backupext=.backup .... "especifica a extensão do arquivo de
-                       backup
-set bex=.backup .......... "simplificação de backupext
-set backupdir=~/.backup,./ "diretório(s) para arquivos de backup
-set bdir ................. "simplificação de `backupdir'
-set nobackup ............. "evita a criação de arquivos de backup
-set nobk ................. "simplificação de `nobackup'
-set cursorline ........... "abreviação de cursor line (destaca
-                       linha  atual)
-set cul .................. "simplificação de `cursorline'
-set ttyfast .............. "melhora o redraw de janelas.
-set columns=88 ........... "deixa a janela com 88 colunas.
-set mousemodel=popup ..... "exibe o conteúdo de folders e
-                       sugestões spell
-set viminfo=%,'50,\"100,/100,:100,n "armazena opções (buffers)
-```
+
+| Opção | Descrição |
+|-------|-----------|
+| `set number` | mostra numeração de linhas |
+| `set nu` | simplificação de `number' |
+| `set showmode` | mostra o modo em que estamos |
+| `set showcmd` | mostra no status os comandos inseridos |
+| `set tabstop=4` | tamanho das tabulações |
+| `set ts=4` | simplificação de `tabstop' |
+| `set shiftwidth=4` | quantidade de espaços de uma tabulação |
+| `set sw=4` | simplificação de `shiftwidth' |
+| `syntax on` | habilita cores |
+| `syn on` | simplificação de `syntax' |
+| `colorscheme tema` | esquema de cores `syntax highlight' |
+| `set autochdir` | configura o diretório de trabalho |
+| `set hls` | destaca com cores os termos procurados |
+| `set incsearch` | habilita a busca incremental |
+| `set ai` | auto indentação |
+| `set aw` | salva automaticamente ao trocar de `buffer' |
+| `set ignorecase` | ignora maiúsculas e minúsculas nas buscas |
+| `set ic` | simplificação de ignorecase |
+| `set smartcase` | numa busca em maiúsculo habilita `case' |
+| `set scs` | sinônimo de `smartcase' |
+| `set backup` | habilita a criação de arquivos de backup |
+| `set bk` | simplificação de `backup' |
+| `set backupext=.backup` | especifica a extensão do arquivo de backup |
+| `set bex=.backup` | simplificação de backupext |
+| `set backupdir=~/.backup,./` | diretório(s) para arquivos de backup |
+| `set bdir` | simplificação de `backupdir' |
+| `set nobackup` | evita a criação de arquivos de backup |
+| `set nobk` | simplificação de `nobackup' |
+| `set cursorline` | abreviação de cursor line (destaca linha atual) |
+| `set cul` | simplificação de `cursorline' |
+| `set ttyfast` | melhora o redraw de janelas |
+| `set columns=88` | deixa a janela com 88 colunas |
+| `set mousemodel=popup` | exibe o conteúdo de folders e sugestões spell |
+| `set viminfo=%,'50,\"100,/100,:100,n` | armazena opções (buffers) |
+
 Se ao iniciar o vim obtivermos mensagens de erros e houver dúvida se o
 erro é no vim ou em sua configuração, pode-se inicia-lo sem que o mesmo
 carregue o arquivo `.vimrc`.

--- a/docs/capitulo_13/como_usar.md
+++ b/docs/capitulo_13/como_usar.md
@@ -5,15 +5,16 @@ title: Como Usar
 O Potwiki trabalha com WikiWords, ou seja, palavras iniciadas com letras
 em maiúsculo e que tenham outra letra em maiúsculo no meio (sem
 espaços). Para iniciar o Potwiki abra o Vim e pressione `\ww`.
-```
-<Leader> é igual a \   - veja :help leader
-\ww  .... abra a sua HomePage
-\wi  .... abre o Wiki index
-\wf  .... segue uma WikiWords (pode ser usado em qualquer buffer)
-\we  .... edite um arquivo Wiki
-\\   .... Fecha o arquivo
-<CR> .... segue WikiWords embaixo do cursor <CR> é igual a Enter
-<Tab>.... move para a próxima WikiWords
-<BS> .... move para os WikiWords anteriores (mesma página)
-\wr  .... recarrega WikiWords
-```
+O `<Leader>` é igual a `\` — veja `:help leader`.
+
+| Comando | Descrição |
+|---------|-----------|
+| `\ww` | abre a sua HomePage |
+| `\wi` | abre o Wiki index |
+| `\wf` | segue uma WikiWord (pode ser usado em qualquer buffer) |
+| `\we` | edita um arquivo Wiki |
+| `\\` | fecha o arquivo |
+| `<CR>` | segue a WikiWord sob o cursor (`<CR>` é igual a Enter) |
+| `<Tab>` | move para a próxima WikiWord |
+| `<BS>` | move para as WikiWords anteriores (mesma página) |
+| `\wr` | recarrega WikiWords |

--- a/docs/capitulo_14/edite_varios_arquivos_de_uma_so_vez.md
+++ b/docs/capitulo_14/edite_varios_arquivos_de_uma_so_vez.md
@@ -6,12 +6,14 @@ O Vim pode abrir vários arquivos que contenham um determinado padrão. Um
 exemplo seria abrir dezenas de arquivos HTML e trocar a ocorrência
 `bgcolor="ffffff"` Para `bgcolor="eeeeee"` Usaríamos a seguinte
 sequência de comandos:
-```
-vim *.html  .................................... abre os arquivos
-:bufdo %s/bgcolor="ffffff"/bgcolor="eeeeee"/ge  substituição
-:wall       .................................... salva todos
-:qa[ll]     .................................... fecha todos
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `vim *.html` | abre os arquivos |
+| `:bufdo %s/bgcolor="ffffff"/bgcolor="eeeeee"/ge` | substituição |
+| `:wall` | salva todos |
+| `:qa[ll]` | fecha todos |
+
 
 Ainda com relação à edição de vários arquivos poderíamos abrir alguns
 arquivos txt e mudar de um para o outro assim:

--- a/docs/capitulo_14/nao_digite_duas_vezes.md
+++ b/docs/capitulo_14/nao_digite_duas_vezes.md
@@ -17,17 +17,18 @@ iab linux GNU/Linux
 ```
 No modo de inserção você pode usar:
 
-```VimL
-Ctrl-y  ........ copia caractere a caractere a linha acima
-Ctrl-e  ........ copia caractere a caractere a linha abaixo
-Ctrl-x Ctrl-l .. completa linhas inteiras
-```
+| Comando | Descrição |
+|---------|-----------|
+| `Ctrl-y` | copia caractere a caractere a linha acima |
+| `Ctrl-e` | copia caractere a caractere a linha abaixo |
+| `Ctrl-x Ctrl-l` | completa linhas inteiras |
+
 Para um trecho muito copiado coloque o seu conteúdo em um registrador:
 
-```VimL
-"ayy ... copia a linha atual para o registrador `a'
-"ap  ... cola o registrador `a'
-```
+| Comando | Descrição |
+|---------|-----------|
+| `"ayy` | copia a linha atual para o registrador `a' |
+| `"ap` | cola o registrador `a' |
 Crie abreviações para erros comuns no seu arquivo de configuração
 (`~/.vimrc`):
 

--- a/docs/capitulo_14/use_marcas.md
+++ b/docs/capitulo_14/use_marcas.md
@@ -3,33 +3,37 @@ title: Use Marcas
 ---
 
 veja a seção [Usando marcas](../capitulo_3/usando_marcas.md).
-```
-ma ..... em modo normal cria uma marca `a'
-'a ..... move o cursor até a marca `a'
-d'a .... deleta até a marca `a'
-y'a .... copia até a marca `a'
 
-gg ... vai para a linha 1 do arquivo
-G .... vai para a última linha do arquivo
-0 .... vai para o início da linha
-$ .... vai para o fim da linha
-fx ... pula até a próxima ocorrência de ``x''
-dfx .. deleta até a próxima ocorrência de ``x''
-g, ... avança na lista de alterações
-g; ... retrocede na lista de alterações
-p .... cola o que foi deletado/copiado abaixo
-P .... cola o que foi deletado/copiado acima
-H .... posiciona o cursor no primeiro caractere da tela
-M .... posiciona o cursor no meio da tela
-L .... posiciona o cursor na última linha da tela
+| Comando | Descrição |
+|---------|-----------|
+| `ma` | em modo normal cria uma marca `a' |
+| `'a` | move o cursor até a marca `a' |
+| `d'a` | deleta até a marca `a' |
+| `y'a` | copia até a marca `a' |
+| `'.` | apóstrofo + ponto, retorna ao último local editado |
+| `''` | retorna ao local do último salto |
 
-* ........ localiza a palavra sob o cursor
-% ........ localiza fechamentos de chaves, parênteses etc.
-g* ....... localiza palavra parcialmente
+Outros comandos úteis de movimentação e busca:
 
-'.  apostrofo + ponto retorna ao último local editado
-'' retorna ao local do ultimo salto
-```
+| Comando | Descrição |
+|---------|-----------|
+| `gg` | vai para a linha 1 do arquivo |
+| `G` | vai para a última linha do arquivo |
+| `0` | vai para o início da linha |
+| `$` | vai para o fim da linha |
+| `fx` | pula até a próxima ocorrência de "x" |
+| `dfx` | deleta até a próxima ocorrência de "x" |
+| `g,` | avança na lista de alterações |
+| `g;` | retrocede na lista de alterações |
+| `p` | cola o que foi deletado/copiado abaixo |
+| `P` | cola o que foi deletado/copiado acima |
+| `H` | posiciona o cursor na primeira linha da tela |
+| `M` | posiciona o cursor no meio da tela |
+| `L` | posiciona o cursor na última linha da tela |
+| `*` | localiza a palavra sob o cursor |
+| `%` | localiza fechamentos de chaves, parênteses etc. |
+| `g*` | localiza palavra parcialmente |
+
 
 Suponha que você está procurando a palavra ‘argc’:
 

--- a/docs/capitulo_15/criando_folders_para_arquivos_latex.md
+++ b/docs/capitulo_15/criando_folders_para_arquivos_latex.md
@@ -10,20 +10,22 @@ set foldmethod=marker
 Adicionar marcadores (*labels*) às seções de um documento *LaTeX*
 ```
 :.s/^\(\\section\)\({.*}\)/\1\2\r\\label\2
-
-: ........... comando
-/ ........... inicia padrão de busca
-^ ........... começo de linha
-\(palavra\) . agrupa um trecho
-\(\\section\) agrupa `\section'
-\\ .......... torna \ literal
-{ ........... chave literal
-.* .......... qualquer caractere em qualquer quantidade
-} ........... chave literal
-/ ........... finaliza parão de busca
-\1 .......... repeter o grupo 1 \(\\section\)
-\2 .......... repete o grupo 2 \({.*\}\)
-\r .......... insere quebra de linha
-\\ .......... insere uma barra invertida
-\2 .......... repete o nome da seção
 ```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:` | comando |
+| `/` | inicia padrão de busca |
+| `^` | começo de linha |
+| `\(palavra\)` | agrupa um trecho |
+| `\(\\section\)` | agrupa `\section' |
+| `\\` | torna \ literal |
+| `{` | chave literal |
+| `.*` | qualquer caractere em qualquer quantidade |
+| `}` | chave literal |
+| `/` | finaliza padrão de busca |
+| `\1` | repete o grupo 1 `\(\\section\)` |
+| `\2` | repete o grupo 2 `\({.*}\)` |
+| `\r` | insere quebra de linha |
+| `\\` | insere uma barra invertida |
+| `\2` | repete o nome da seção |

--- a/docs/capitulo_15/criando_secoes_latex.md
+++ b/docs/capitulo_15/criando_secoes_latex.md
@@ -16,16 +16,18 @@ o comando abaixo substitui
 
 ```
 :.s/^==\s\?\([^=]*\)\s\?==/\\section{\1}/g
-
-: ......... comando
-. ......... linha atual
-s ......... substitua
-^ ......... começo de linha
-== ........ dois sinais de igual
-\s\? ...... seguido ou não de espaço
-[^=] ...... não pode haver = (^ dentro de [] é negação)
-* ......... diz que o que vem antes pode vir zero ou mais vezes
-\s\? ...... seguido ou não de espaço
-\\ ........ insere uma barra invertida
-\1 ........ repete o primeiro trecho entre ()
 ```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:` | comando |
+| `.` | linha atual |
+| `s` | substitua |
+| `^` | começo de linha |
+| `==` | dois sinais de igual |
+| `\s\?` | seguido ou não de espaço |
+| `[^=]` | não pode haver = (^ dentro de [] é negação) |
+| `*` | diz que o que vem antes pode vir zero ou mais vezes |
+| `\s\?` | seguido ou não de espaço |
+| `\\` | insere uma barra invertida |
+| `\1` | repete o primeiro trecho entre () |

--- a/docs/capitulo_2/comentando_rapidamente_um_trecho.md
+++ b/docs/capitulo_2/comentando_rapidamente_um_trecho.md
@@ -10,12 +10,13 @@ Tomando como exemplo um trecho de código como abaixo:
 8   input{capitulo8}
 9   input{capitulo9}
 ```
-Se desejamos comentar da linha 4 até a linha 9 podemos fazer:
-```
-posicionar o cursor no começo da linha 4
-Ctrl-v ........... inicia seleção por blocos
-5j ............... estende a seleção até o fim
-Shift-i .......... inicia inserção no começo da linha
-% ................ insere comentário (LaTeX)
-Esc .............. sai do modo de inserção
-```
+Se desejamos comentar da linha 4 até a linha 9, posicionamos o cursor no
+começo da linha 4 e fazemos:
+
+| Comando | Descrição |
+|---------|-----------|
+| `Ctrl-v` | inicia seleção por blocos |
+| `5j` | estende a seleção até o fim |
+| `Shift-i` | inicia inserção no começo da linha |
+| `%` | insere comentário (LaTeX) |
+| `Esc` | sai do modo de inserção |

--- a/docs/capitulo_2/escrevendo_o_texto.md
+++ b/docs/capitulo_2/escrevendo_o_texto.md
@@ -3,15 +3,17 @@ o modo de inserção, que é o modo onde escreve-se o texto naturalmente.
 
 Para se entrar em modo de inserção, estando em modo normal, pode-se
 pressionar qualquer uma das teclas abaixo:
-```
-i ..... entra no modo de inserção antes do caractere atual
-I ..... entra no modo de inserção no começo da linha
-a ..... entra no modo de inserção após o caractere atual
-A ..... entra no modo de inserção no final da linha
-o ..... entra no modo de inserção uma linha abaixo
-O ..... entra em modo de inserção uma linha cima
-<Esc> . sai do modo de inserção
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `i` | entra no modo de inserção antes do caractere atual |
+| `I` | entra no modo de inserção no começo da linha |
+| `a` | entra no modo de inserção após o caractere atual |
+| `A` | entra no modo de inserção no final da linha |
+| `o` | entra no modo de inserção uma linha abaixo |
+| `O` | entra em modo de inserção uma linha acima |
+| `<Esc>` | sai do modo de inserção |
+
 Uma vez no modo de inserção todas as teclas são exatamente como nos
 outros editores simples, caracteres que constituem o conteúdo do texto
 sendo digitado. O que inclui as teclas de edição de caracteres.

--- a/docs/capitulo_2/ordenando.md
+++ b/docs/capitulo_2/ordenando.md
@@ -40,5 +40,6 @@ Você pode fazer a ordenação em um intervalo assim:
 O comando acima diz “`*Ordene numericamente da linha 1 até a linha
 15*`”. Podemos ainda ordenar à partir de uma coluna:
 ```
-:sort /.*\%8v/   ..... ordena à partir do 8º caractere
+:sort /.*\%8v/
 ```
+O comando acima ordena a partir do 8º caractere.

--- a/docs/capitulo_2/repetindo_a_digitacao_de_linhas.md
+++ b/docs/capitulo_2/repetindo_a_digitacao_de_linhas.md
@@ -2,11 +2,13 @@
 title: Repetindo a digitação de linhas
 ---
 
-```
-" atalhos para o modo insert
-Ctrl-y ......... repete linha acima
-Ctrl-e ......... repete linha abaixo
-Ctrl-x Ctrl-l .. repete linhas inteiras
-Ctrl-a ......... repete a última inserção
-```
+Atalhos para o modo de inserção:
+
+| Comando | Descrição |
+|---------|-----------|
+| `Ctrl-y` | repete linha acima |
+| `Ctrl-e` | repete linha abaixo |
+| `Ctrl-x Ctrl-l` | repete linhas inteiras |
+| `Ctrl-a` | repete a última inserção |
+
 Para saber mais sobre repetição de comandos veja o capítulo [Repetição de comandos](../capitulo_8/repeticao_de_comandos.md).

--- a/docs/capitulo_2/salvando.md
+++ b/docs/capitulo_2/salvando.md
@@ -20,14 +20,16 @@ Também existe o comando:
 salva o arquivo com um novo nome e muda para esse novo arquivo (o
 arquivo original não é apagado). Para sair do editor, salvando o arquivo
 atual, digite `:x` (ou `:wq`).
-```
-:w ............................ salva
-:wq  .......................... salva e sai
-:w nome ....................... salvar como
-:saveas nome .................. salvar como
-:sav nome ..................... mesmo que "saveas nome"
-:x ............................ salva se existirem modificações
-:10,20 w! ~/Desktop/teste.txt . salva um trecho para outro arquivo
-:w! ........................... salvamento forçado
-:e! ........................... reinicia a edição ignorando alterações
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:w` | salva |
+| `:wq` | salva e sai |
+| `:w nome` | salvar como |
+| `:saveas nome` | salvar como |
+| `:sav nome` | mesmo que "saveas nome" |
+| `:x` | salva se existirem modificações |
+| `:10,20 w! ~/Desktop/teste.txt` | salva um trecho para outro arquivo |
+| `:w!` | salvamento forçado |
+| `:e!` | reinicia a edição ignorando alterações |
+

--- a/docs/capitulo_2/substituindo_tabulacoes_por_espacos.md
+++ b/docs/capitulo_2/substituindo_tabulacoes_por_espacos.md
@@ -13,10 +13,7 @@ Para fazer o contrário usamos algo como:
 ```
 :%s/\s\{4,}/<pressiona-se ctrl-i>/g
 ```
-onde
-```
-<Ctrl-i>...... insere uma tabulação
-```
+onde `<Ctrl-i>` insere uma tabulação.
 Explicando:
 
 | Comando | Descrição |

--- a/docs/capitulo_2/usando_grep_interno_do_vim.md
+++ b/docs/capitulo_2/usando_grep_interno_do_vim.md
@@ -11,8 +11,10 @@ minúsculas.
 
 Obs: o Vim busca à partir do diretório atual, para se descobrir o
 diretório atual ou mudá-lo:
-```
-:pwd ........... exibe o diretório atual
-:cd /diretório   muda de diretório
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:pwd` | exibe o diretório atual |
+| `:cd /diretório` | muda de diretório |
+
 

--- a/docs/capitulo_3/movendo-se_no_documento.md
+++ b/docs/capitulo_3/movendo-se_no_documento.md
@@ -6,15 +6,15 @@ movimentação, faz-se útil uma breve recapitulação de conceitos
 relacionados. Para se entrar em modo de inserção, estando em modo
 normal, pode-se pressionar qualquer uma das teclas abaixo:
 
-```
-i ..... entra no modo de inserção antes do caractere atual
-I ..... entra no modo de inserção no começo da linha
-a ..... entra no modo de inserção após o caractere atual
-A ..... entra no modo de inserção no final da linha
-o ..... entra no modo de inserção uma linha abaixo
-O ..... entra em modo de inserção uma linha cima
-<Esc> . sai do modo de inserção
-```
+| Comando | Descrição |
+|---------|-----------|
+| `i` | entra no modo de inserção antes do caractere atual |
+| `I` | entra no modo de inserção no começo da linha |
+| `a` | entra no modo de inserção após o caractere atual |
+| `A` | entra no modo de inserção no final da linha |
+| `o` | entra no modo de inserção uma linha abaixo |
+| `O` | entra em modo de inserção uma linha acima |
+| `<Esc>` | sai do modo de inserção |
 
 Uma vez no modo de inserção todas as teclas são exatamente como nos
 outros editores simples, caracteres que constituem o conteúdo do texto
@@ -54,51 +54,45 @@ No vim é possível realizar diversos tipos de movimentos, também
 conhecidos como saltos no documento. A lista abaixo aponta o comandos de
 salto típicos.
 
-```
-gg .... vai para o início do arquivo
-G ..... vai para o final do arquivo
-0 ..... vai para o início da linha
-^ ..... vai para o primeiro caractere da linha (ignora
-        espaços)
-$ ..... vai para o final da linha
-25gg .. salta para a linha 25
-'' .... salta para a linha da última posição em que o cursor
-        estava
-fx .... para primeira ocorrência de x
-tx .... Para ir para uma letra antes de x
-Fx .... Para ir para ocorrência anterior de x
-Tx .... Para ir para uma letra após o último x
-* ..... Próxima ocorrência de palavra sob o cursor
-`' .... salta exatamente para a posição em que o cursor
-        estava
-gd .... salta para declaração de variável sob o cursor
-gD .... salta para declaração (global) de variável sob o
-        cursor
-w ..... move para o início da próxima palavra
-W ..... pula para próxima palavra (desconsidera hífens)
-E ..... pula para o final da próxima palavra (desconsidera
-        hifens)
-e ..... move o cursor para o final da próxima palavra
-zt .... rola a tela deixando a linha atual no topo
-zz .... rola a tela deixando a linha atual no centro
-zb .... rola a tela deixando a linha atual embaixo
-n ..... move o cursor para a próxima ocorrência da busca
-N ..... move o cursor para a ocorrência anterior da busca
-```
+| Comando | Descrição |
+|---------|-----------|
+| `gg` | vai para o início do arquivo |
+| `G` | vai para o final do arquivo |
+| `0` | vai para o início da linha |
+| `^` | vai para o primeiro caractere da linha (ignora espaços) |
+| `$` | vai para o final da linha |
+| `25gg` | salta para a linha 25 |
+| `''` | salta para a linha da última posição em que o cursor estava |
+| `fx` | para primeira ocorrência de x |
+| `tx` | para ir para uma letra antes de x |
+| `Fx` | para ir para ocorrência anterior de x |
+| `Tx` | para ir para uma letra após o último x |
+| `*` | próxima ocorrência de palavra sob o cursor |
+| ``` `' ``` | salta exatamente para a posição em que o cursor estava |
+| `gd` | salta para declaração de variável sob o cursor |
+| `gD` | salta para declaração (global) de variável sob o cursor |
+| `w` | move para o início da próxima palavra |
+| `W` | pula para próxima palavra (desconsidera hífens) |
+| `E` | pula para o final da próxima palavra (desconsidera hifens) |
+| `e` | move o cursor para o final da próxima palavra |
+| `zt` | rola a tela deixando a linha atual no topo |
+| `zz` | rola a tela deixando a linha atual no centro |
+| `zb` | rola a tela deixando a linha atual embaixo |
+| `n` | move o cursor para a próxima ocorrência da busca |
+| `N` | move o cursor para a ocorrência anterior da busca |
 
 Também é possível efetuar saltos e fazer algo mais ao mesmo tempo, a
 lista abaixo aponta algumas dessas possibilidades.
 
-```
-gv .... repete a última seleção visual e posiciona o cursor
-        neste local
-% ..... localiza parênteses correspondente
-o ..... letra `o', alterna extremos de seleção visual
-yG .... copia da linha atual até o final do arquivo
-d$ .... deleta do ponto atual até o final da linha
-gi .... entra em modo de inserção no ponto da última edição
-gf .... abre o arquivo sob o cursor
-```
+| Comando | Descrição |
+|---------|-----------|
+| `gv` | repete a última seleção visual e posiciona o cursor neste local |
+| `%` | localiza parênteses correspondente |
+| `o` | letra `o', alterna extremos de seleção visual |
+| `yG` | copia da linha atual até o final do arquivo |
+| `d$` | deleta do ponto atual até o final da linha |
+| `gi` | entra em modo de inserção no ponto da última edição |
+| `gf` | abre o arquivo sob o cursor |
 
 Para o Vim “*palavras-separadas-por-hífen*”
 são consideradas em separado, portanto se você usar, em modo normal

--- a/docs/capitulo_3/paginando.md
+++ b/docs/capitulo_3/paginando.md
@@ -1,20 +1,19 @@
 Para rolar uma página de cada vez (em modo normal)
 
-```
-Ctrl-f
-Ctrl-b
-
-:h jumps . ajuda sobre a lista de saltos
-:jumps ... exibe a lista de saltos
-Ctrl-i ... salta para a posição mais recente
-Ctrl-o ... salta para a posição mais antiga
-'0 ....... abre o último arquivo editado
-'1 ....... abre o penúltimo arquivo editado
-gd ....... pula para a definição de uma variável
-} ........ pula para o fim do parágrafo
-10| ...... pula para a coluna 10
-[i ....... pula para definição de variável sob o cursor
-```
+| Comando | Descrição |
+|---------|-----------|
+| `Ctrl-f` | avança uma página |
+| `Ctrl-b` | volta uma página |
+| `:h jumps` | ajuda sobre a lista de saltos |
+| `:jumps` | exibe a lista de saltos |
+| `Ctrl-i` | salta para a posição mais recente |
+| `Ctrl-o` | salta para a posição mais antiga |
+| `'0` | abre o último arquivo editado |
+| `'1` | abre o penúltimo arquivo editado |
+| `gd` | pula para a definição de uma variável |
+| `}` | pula para o fim do parágrafo |
+| <code>10&#124;</code> | pula para a coluna 10 |
+| `[i` | pula para definição de variável sob o cursor |
 
 Observação: lembre-se
 

--- a/docs/capitulo_4/criando_dobras_usando_o_modo_visual.md
+++ b/docs/capitulo_4/criando_dobras_usando_o_modo_visual.md
@@ -8,8 +8,10 @@ Para iniciar a seleção visual
 | `zf` | cria a dobra na seleção ativa |
 
 Um modo inusitado de se criar dobras é:
-```
-Shift-v ..... inicia seleção visual
-/chapter/-2 . extende a seleção até /chapter -2 linhas
-zf .......... cria a dobra
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `Shift-v` | inicia seleção visual |
+| `/chapter/-2` | estende a seleção até /chapter -2 linhas |
+| `zf` | cria a dobra |
+

--- a/docs/capitulo_4/manipulando_dobras.md
+++ b/docs/capitulo_4/manipulando_dobras.md
@@ -1,26 +1,28 @@
 Os principais comandos relativos ao uso de dobras são:
-```
-zo ................ abre a dobra
-zO ................ abre a dobra, recursivamente
-za ................ abre/fecha (alterna) a dobra
-zA ................ abre/fecha (alterna) a dobra, recursivamente
-zR ................ abre todas as dobras do arquivo atual
-zM ................ fecha todas as dobras do arquivo atual
-zc ................ fecha uma dobra
-zC ................ fecha a dobra abaixo do cursor, recursivamente
-zfap .............. cria uma dobra para o parágrafo 'ap' atual
-zf/casa ........... cria uma dobra até a palavra casa
-zf'a .............. cria uma dobra até a marca 'a'
-zd ................ apaga a dobra (não o seu conteúdo)
-zj ................ move para o início da próxima dobra
-zk ................ move para o final da dobra anterior
-[z ................ move o cursor para início da dobra aberta
-]z ................ move o cursor para o fim da dobra aberta
-zi ................ desabilita ou habilita as dobras
-zm, zr ............ diminui/aumenta nível da dobra 'fdl'
-:set fdl=0 ........ nível da dobra 0 (foldlevel)
-:set foldcolumn=4 . mostra uma coluna ao lado da numeração
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `zo` | abre a dobra |
+| `zO` | abre a dobra, recursivamente |
+| `za` | abre/fecha (alterna) a dobra |
+| `zA` | abre/fecha (alterna) a dobra, recursivamente |
+| `zR` | abre todas as dobras do arquivo atual |
+| `zM` | fecha todas as dobras do arquivo atual |
+| `zc` | fecha uma dobra |
+| `zC` | fecha a dobra sob o cursor, recursivamente |
+| `zfap` | cria uma dobra para o parágrafo 'ap' atual |
+| `zf/casa` | cria uma dobra até a palavra casa |
+| `zf'a` | cria uma dobra até a marca 'a' |
+| `zd` | apaga a dobra (não o seu conteúdo) |
+| `zj` | move para o início da próxima dobra |
+| `zk` | move para o final da dobra anterior |
+| `[z` | move o cursor para início da dobra aberta |
+| `]z` | move o cursor para o fim da dobra aberta |
+| `zi` | desabilita ou habilita as dobras |
+| `zm`, `zr` | diminui/aumenta nível da dobra 'fdl' |
+| `:set fdl=0` | nível da dobra 0 (foldlevel) |
+| `:set foldcolumn=4` | mostra uma coluna ao lado da numeração |
+
 Para abrir e fechar as dobras usando a barra de espaços coloque o trecho
 abaixo no seu arquivo de configuração do Vim (`.vimrc`) - veja o
 [Como editar preferências no Vim](../capitulo_12/como_editar_preferencias_no_vim.md).

--- a/docs/capitulo_5/como_colocar_um_pedaco_de_texto_em_um_registrador.md
+++ b/docs/capitulo_5/como_colocar_um_pedaco_de_texto_em_um_registrador.md
@@ -8,10 +8,12 @@ title: Como colocar um pedaço de texto em um registrador?
 | `"ay10j` | coloca no registrador `a' as próximas 10 linhas `10j' |
 
 Pode-se fazer:
-```
-<Esc> ...... para ter certeza que está em modo normal
-"ap ........ registrador a `paste', ou seja, cole
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `<Esc>` | para ter certeza que está em modo normal |
+| `"ap` | registrador a `paste', ou seja, cole |
+
 Em modo de inserção faz-se:
 ```
 Ctrl-r a
@@ -19,18 +21,22 @@ Ctrl-r a
 Há situações em que se tem caracteres não "*ascii* " que são complicados
 de se colocar em uma busca ou substituição, nestes casos pode-se usar os
 seguintes comandos:
-```
-"ayl ............. copia para o registrador `a' o caractere sob o cursor
-:%s/<c-r>a/char .. substitui o conteúdo do registrador `a' por char
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `"ayl` | copia para o registrador `a' o caractere sob o cursor |
+| `:%s/<c-r>a/char` | substitui o conteúdo do registrador `a' por char |
+
 Pode-se ainda usar esta técnica para copiar rapidamente comentários do
 `bash`[^1], representados pelo caracteres `#`, em *modo
 normal* usando o atalho `0yljP`.
-```
-0 ............... posiciona o cursor no início a linha
-yl .............. copia o caractere sob o cursor
-j ............... desce uma linha
-P ............... cola o caractere copiado
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `0` | posiciona o cursor no início da linha |
+| `yl` | copia o caractere sob o cursor |
+| `j` | desce uma linha |
+| `P` | cola o caractere copiado |
+
 
 [^1]: Interpretador de comandos do GNU/Linux

--- a/docs/capitulo_5/como_criar_um_registrador_em_modo_visual.md
+++ b/docs/capitulo_5/como_criar_um_registrador_em_modo_visual.md
@@ -2,9 +2,9 @@
 title: Como criar um registrador em modo visual?
 ---
 
-Inicie a seleção visual com o atalho
+Inicie a seleção visual de linhas inteiras com o atalho
 ```
-Shift-v ..... seleciona linhas inteiras
+Shift-v
 ```
 pressione a letra `j` até chegar ao ponto desejado, agora faça
 ```

--- a/docs/capitulo_5/como_definir_um_registrador_no_vimrc.md
+++ b/docs/capitulo_5/como_definir_um_registrador_no_vimrc.md
@@ -48,10 +48,18 @@ As atribuições acima correspondem a:
 E digitar ,d normalmente
 
 Desmistificando o strftime
-```
-" %d=dia %m=mes %Y=ano %H=hora %M=minuto %c=data-completa
-:h strftime ........ ajuda completa sobre o comando
-```
+
+| Formato | Significado |
+|---------|-------------|
+| `%d` | dia |
+| `%m` | mês |
+| `%Y` | ano |
+| `%H` | hora |
+| `%M` | minuto |
+| `%c` | data completa |
+
+Use `:h strftime` para a ajuda completa sobre a função.
+
 e inserir em modo normal assim:
 ```
 "dp

--- a/docs/capitulo_5/registrador_de_expressoes.md
+++ b/docs/capitulo_5/registrador_de_expressoes.md
@@ -25,24 +25,25 @@ linha 3 tem o valor 450,
 Acompanhe os passos para a criação de uma macro permite fazer uma
 sequência de quantas linhas forem necessárias com o incremento proposto
 acima.
-```
-<Esc>  ......... sai do modo de inserção
-qa ............. inicia a macro
-yy ............. copia a primeira linha
-p .............. cola a linha copiada
-w .............. pula para o número `1'
-<Ctrl-a> ....... incrementa o número (agora 2)
-4w ............. avança 4 palavras até 150
-"ndw ........... apaga o `150' para o registrador "n
-i .............. entra em modo de inserção
-Ctrl-r = ....... abre o registrador de expressões
-Ctrl-r n + 150   insere dentro do registrador de expressões
-                 o registrador "n
-<Enter>  ........ executa o registrador de expressões
-<Esc> ........... sai do modo de inserção
-0 ............... vai para o começo da linha
-q ............... para a gravação da macro
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `<Esc>` | sai do modo de inserção |
+| `qa` | inicia a macro |
+| `yy` | copia a primeira linha |
+| `p` | cola a linha copiada |
+| `w` | pula para o número `1' |
+| `<Ctrl-a>` | incrementa o número (agora 2) |
+| `4w` | avança 4 palavras até 150 |
+| `"ndw` | apaga o `150' para o registrador "n |
+| `i` | entra em modo de inserção |
+| `Ctrl-r =` | abre o registrador de expressões |
+| `Ctrl-r n + 150` | insere dentro do registrador de expressões o registrador "n |
+| `<Enter>` | executa o registrador de expressões |
+| `<Esc>` | sai do modo de inserção |
+| `0` | vai para o começo da linha |
+| `q` | para a gravação da macro |
+
 Agora posicione o cursor no começo da linha e pressione `10@a`.
 
 Na seção [Mapeamento para Calcular Expressões](../capitulo_12/mapeamentos.md) há mais dicas

--- a/docs/capitulo_5/registradores_de_buscas.md
+++ b/docs/capitulo_5/registradores_de_buscas.md
@@ -12,6 +12,11 @@ claro o uso do registrador de buscas "/". Pode-se usar um registrador nomeado
 de 'a-z' assim:
 ```
 let @a="new"
-:%s/old/\=@a/g ...... substitui 'old' por new
-\=@a ................ faz referência ao registrador `a'
+:%s/old/\=@a/g
 ```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:%s/old/\=@a/g` | substitui 'old' por new |
+| `\=@a` | faz referência ao registrador `a' |
+

--- a/docs/capitulo_6/destacando_padroes.md
+++ b/docs/capitulo_6/destacando_padroes.md
@@ -3,7 +3,9 @@ title: Destacando Padrões
 ---
 
 Você pode destacar linhas com mais de 30 caracteres assim:
-```
-:match ErrorMsg /\%>30v/ . destaca linhas maiores que 30 caracteres
-:match none .............. remove o destaque
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:match ErrorMsg /\%>30v/` | destaca linhas maiores que 30 caracteres |
+| `:match none` | remove o destaque |
+

--- a/docs/capitulo_6/exemplos.md
+++ b/docs/capitulo_6/exemplos.md
@@ -19,22 +19,24 @@ Usando `\c` o Vim encontrará “*palavra*”,
 “*PALAVRA*”. Uma dica é colocar no seu arquivo
 de configuração “vimrc” veja o capítulo
 [Como editar preferências no Vim](../capitulo_12/como_editar_preferencias_no_vim.md).
-```
-set ignorecase .. ignora maiúsculas e minúsculas na busca
-set smartcase ... se busca contiver maiúsculas ele passa a
-                  considerá-las
-set hlsearch .... mostra o que está sendo buscado em cores
-set incsearch ... ativa a busca incremental
-```
+
+| Opção | Descrição |
+|-------|-----------|
+| `set ignorecase` | ignora maiúsculas e minúsculas na busca |
+| `set smartcase` | se busca contiver maiúsculas ele passa a considerá-las |
+| `set hlsearch` | mostra o que está sendo buscado em cores |
+| `set incsearch` | ativa a busca incremental |
+
 se você não sabe ainda como colocar estas preferências no arquivo de
 configuração pode ativa-las em modo de comando precedendo-as com dois
 pontos, assim:
 ```
 :set ignorecase<Enter>
 ```
-Substituições com confirmação:
+Substituições com confirmação, em que o `c` no final habilita a
+confirmação:
 ```
-:%s/word/palavra/c ..... o `c' no final habilita a confirmação
+:%s/word/palavra/c
 ```
 Procurando palavras repetidas
 ```
@@ -57,14 +59,22 @@ World
 Buscar linhas de até 30 caracteres de comprimento
 ```
 /^.\{,30\}$
-
-^  ..... representa começo de linha
-.  ..... representa qualquer caractere
-
-:%s/<[^>]*>//g ... apaga tags HTML/XML
-:%g/^$/d ......... apaga linhas vazias
-:%s/^[\ \t]*\n//g  apaga linhas vazias
 ```
+
+| Comando | Descrição |
+|---------|-----------|
+| `^` | representa começo de linha |
+| `.` | representa qualquer caractere |
+| `\{,30\}` | no máximo 30 vezes |
+| `$` | representa fim de linha |
+
+Outras substituições úteis:
+
+| Comando | Descrição |
+|---------|-----------|
+| `:%s/<[^>]*>//g` | apaga tags HTML/XML |
+| `:%g/^$/d` | apaga linhas vazias |
+| `:%s/^[\ \t]*\n//g` | apaga linhas vazias |
 Remover duas ou mais linhas vazias entre parágrafos diminuindo para uma
 só linha vazia.
 ```

--- a/docs/capitulo_6/filtrando_arquivos_com_o_vimgrep.md
+++ b/docs/capitulo_6/filtrando_arquivos_com_o_vimgrep.md
@@ -2,10 +2,10 @@ Por vezes sabemos que aquela anotação foi feita, mas no momento
 esquecemos em qual arquivo está, no exemplo abaixo procuramos a palavra
 dicas à partir da nossa pasta pessoal pela palavra ‘dicas’ em todos os
 arquivos com extensão ‘txt’.
+O `~/` equivale a `/home/user`.
 ```
-~/ ............ equivale a /home/user
 :lvimgrep /dicas/gj ~/**/*.txt | lopen
 :vimgrep /dicas/gj **/*.txt | copen
 :vimgrep dicas **/*.txt | copen
-:h lvim ....... ajuda sobre o comando
 ```
+Use `:h lvim` para a ajuda sobre o comando.

--- a/docs/capitulo_6/juncao_de_linhas_com_vim.md
+++ b/docs/capitulo_6/juncao_de_linhas_com_vim.md
@@ -23,12 +23,13 @@ Para isto, basta executar o comando:
 :g/^Matrícula/s/\n/ - /
 ```
 Explicando:
-```
-s/isto/aquilo/g .. substitui isto por aquilo
-g ................ comando global
-/................. inicia padrão de busca
-^ ................ indica começo de linha
-Matrícula ........ palavra a ser buscada
-s ................ inicia substituição
-/\n/ - / ......... troca quebra de linha `\n`, por `-`
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `s/isto/aquilo/g` | substitui isto por aquilo |
+| `g` | comando global |
+| `/` | inicia padrão de busca |
+| `^` | indica começo de linha |
+| `Matrícula` | palavra a ser buscada |
+| `s` | inicia substituição |
+| `/\n/ - /` | troca quebra de linha `\n` por `-` |

--- a/docs/capitulo_6/o_comando_global_g.md
+++ b/docs/capitulo_6/o_comando_global_g.md
@@ -26,16 +26,19 @@ numerar linhas:
 Outro modo de inserir números de linha
 ```
 :%s/^/\=line('.').'  '
-
-: ............ comando
-% ............ em todo o arquivo
-s ............ substituição
-/ ............ inicio da busca
-^ ............ começo de linha
-/ ............ inicio da substituição
-\=line('.') .. corresponde ao nº da linha atual
-.'  ' ........ concatena um espaço após o nº
 ```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:` | comando |
+| `%` | em todo o arquivo |
+| `s` | substituição |
+| `/` | inicio da busca |
+| `^` | começo de linha |
+| `/` | inicio da substituição |
+| `\=line('.')` | corresponde ao nº da linha atual |
+| `.'  '` | concatena um espaço após o nº |
+
 Para copiar linhas começadas com *Error* para o final do
 arquivo faça:
 ```
@@ -87,7 +90,7 @@ Copiar linhas que contém um padrão e a linha subsequente para o final:
 ```
 Deletar linhas que não contenham um padrão:
 ```
-:v/dicas/d  ..... deleta linhas que não contenham `dicas'
+:v/dicas/d
 ```
 Incrementar números no começo da linha:
 ```
@@ -96,20 +99,22 @@ Incrementar números no começo da linha:
 Sublinhar linhas começadas com *Chapter*:
 ```
 :g/^Chapter/t.|s/./-/g
-
-: ........ comando
-g ........ global
-/ ........ inicio de um padrão
-^ ........ começo de linha
-Chapter .. palavra literal
-/ ........ fim do padrão
-t ........ copia
-. ........ linha atual
-s ........ substitua
-/ ........ inicio de um padrão
-. ........ qualquer caractere
-/ ........ início da substituição
-- ........ por traço
-/ ........ fim da substituição
-g ........ em todas as ocorrências
 ```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:` | comando |
+| `g` | global |
+| `/` | inicio de um padrão |
+| `^` | começo de linha |
+| `Chapter` | palavra literal |
+| `/` | fim do padrão |
+| `t` | copia |
+| `.` | linha atual |
+| `s` | substitua |
+| `/` | inicio de um padrão |
+| `.` | qualquer caractere |
+| `/` | início da substituição |
+| `-` | por traço |
+| `/` | fim da substituição |
+| `g` | em todas as ocorrências |

--- a/docs/capitulo_6/obtendo_informacoes_do_arquivo.md
+++ b/docs/capitulo_6/obtendo_informacoes_do_arquivo.md
@@ -27,8 +27,10 @@ a barra de status que faz com que a mesma exiba o código do caractere
 sob o cursor na seção [Função para barra de status](../capitulo_12/funcoes.md). O caractere de
 final de linha do Windows/DOS pode ser inserido com a seguinte
 combinação de teclas:
-```
-i ............ entra em modo de inserção
-<INSERT> ..... entra em modo de inserção
-Ctrl-v Ctrl-m  insere o simbolo ^M (terminador de linha DOS)
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `i` | entra em modo de inserção |
+| `<INSERT>` | entra em modo de inserção |
+| `Ctrl-v Ctrl-m` | insere o símbolo ^M (terminador de linha DOS) |
+

--- a/docs/capitulo_6/selecionando_ou_deletando_o_conteudo_de_tags_HTML.md
+++ b/docs/capitulo_6/selecionando_ou_deletando_o_conteudo_de_tags_HTML.md
@@ -4,11 +4,13 @@ title: Selecionando ou deletando o conteúdo de tags HTML
 
 Selecionando ou deletando conteúdo de tags HTML
 -------------------------------------------------------------------
-```
-<tag> conteúdo da tag </tag>
-basta usar (em modo normal) as teclas
-vit ............... visual `inner tag | esta tag'
-```
+Em uma estrutura como `<tag> conteúdo da tag </tag>`, basta usar (em modo
+normal) as teclas:
+
+| Comando | Descrição |
+|---------|-----------|
+| `vit` | visual *inner tag*, seleciona o conteúdo desta tag |
+
 Este recurso também funciona com parênteses
 
 | Comando | Descrição |

--- a/docs/capitulo_6/usando_expressoes_regulares_em_buscas.md
+++ b/docs/capitulo_6/usando_expressoes_regulares_em_buscas.md
@@ -40,39 +40,45 @@ Já com a opção “*very magic*” `\v` usa-se bem menos
 escapes:
 ```
 :%s/\v\d{5}(\D+)\d{3}/\1/
-
-" explicação do comando acima
-: ......... comando
-% ......... em todo arquivo
-s ......... substitua
-/ ......... inicia padrão de busca
-\v ........ use very magic mode
-\d ........ dígitos
-{5} ....... 5 vezes
-( ........ inicia um grupo
-\D ........ seguido de não dígitos
-)  ........ fecha um grupo
-+ ......... uma ou mais vezes
-\d ........ novamente dígitos
-{3} ....... três vezes
-/ ......... inicio da substituição
-\1 ........ referencia o grupo 1
 ```
+
+Explicação do comando acima:
+
+| Comando | Descrição |
+|---------|-----------|
+| `:` | comando |
+| `%` | em todo arquivo |
+| `s` | substitua |
+| `/` | inicia padrão de busca |
+| `\v` | use very magic mode |
+| `\d` | dígitos |
+| `{5}` | 5 vezes |
+| `(` | inicia um grupo |
+| `\D` | seguido de não dígitos |
+| `)` | fecha um grupo |
+| `+` | uma ou mais vezes |
+| `\d` | novamente dígitos |
+| `{3}` | três vezes |
+| `/` | inicio da substituição |
+| `\1` | referencia o grupo 1 |
 Analisando o exemplo anterior, a linha de raciocínio foi a de “manter o
 texto entre os dígitos”, o que pode ser traduzido, em uma outra forma de
 raciocínio, como “remover os dígitos”.
 ```
 :%s/\d//g
-
-" explicação do comando acima
-% ......... em todo arquivo
-s ......... substitua
-/ ......... inicia padrão de busca
-\d ........ ao encontrar um dígito
-/ ......... substituir por
-vazio ..... exato, substituir por vazio
-/g ........ a substituição se torna global
 ```
+
+Explicação do comando acima:
+
+| Comando | Descrição |
+|---------|-----------|
+| `%` | em todo arquivo |
+| `s` | substitua |
+| `/` | inicia padrão de busca |
+| `\d` | ao encontrar um dígito |
+| `/` | substituir por |
+| vazio | exato, substituir por vazio |
+| `/g` | a substituição se torna global |
 A opção `g` — de *global* — faz a substituição valer para todas as
 ocorrências do padrão em cada linha. Sem ela, apenas a primeira
 ocorrência de cada linha é substituída.
@@ -93,21 +99,24 @@ sistema ao idioma local, esta é a mágica implementada por estas classes.
 Para usar estas classes fazemos:
 ```
 :%s/[[:lower:]]/\U&/g
+```
 
 Explicando o comando acima:
-: ....... modo de comando
-% ....... em todo o arquivo atual
-s ....... substitua
-/ ....... inicia o padrão a ser buscado
-[ ....... inicia um grupo
-[: ...... inicia uma classe POSIX
-lower ... letras minúsculas
-:] ...... termina a classe POSIX
-] ....... termina o grupo
-/ ....... inicia substituição
-\U ...... para maiúsculo
-& ....... correponde ao que foi buscado
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:` | modo de comando |
+| `%` | em todo o arquivo atual |
+| `s` | substitua |
+| `/` | inicia o padrão a ser buscado |
+| `[` | inicia um grupo |
+| `[:` | inicia uma classe POSIX |
+| `lower` | letras minúsculas |
+| `:]` | termina a classe POSIX |
+| `]` | termina o grupo |
+| `/` | inicia substituição |
+| `\U` | para maiúsculo |
+| `&` | corresponde ao que foi buscado |
 Nem todas as classes *POSIX* conseguem pegar caracteres
 acentuados, portanto deve-se habilitar o destaque colorido para buscas
 usando:

--- a/docs/capitulo_7/file_explorer.md
+++ b/docs/capitulo_7/file_explorer.md
@@ -3,13 +3,16 @@ title: File Explorer
 ---
 
 Para abrir o gerenciador de arquivos do Vim use:
-```
-:Vex ............ abre o file explorer verticalmente
-:Sex ............ abre o file explorer em nova janela
-:Tex ............ abre o file explorer em nova aba
-:Ex ............. abre o file explorer na janela atual
-após abrir chame a ajuda <F1>
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `:Vex` | abre o file explorer verticalmente |
+| `:Sex` | abre o file explorer em nova janela |
+| `:Tex` | abre o file explorer em nova aba |
+| `:Ex` | abre o file explorer na janela atual |
+
+Após abrir, chame a ajuda com `<F1>`.
+
 O `:Vex` abre a janela à esquerda. Para que ela abra à direita, coloque a
 linha abaixo no seu `~/.vimrc`
 ```

--- a/docs/capitulo_7/modos_de_divisao_da_janela.md
+++ b/docs/capitulo_7/modos_de_divisao_da_janela.md
@@ -27,7 +27,7 @@ outro diferente). O comando é `:split` (ou `:sp`), e por padrão a nova
 janela aparece acima da atual. Para que ela apareça abaixo, coloque no
 seu `~/.vimrc`:
 ```
-:set splitbelow .... a janela nova abre abaixo da atual
+set splitbelow
 ```
 ### Utilizando split vertical
 
@@ -37,5 +37,5 @@ a única diferença o modo como a tela é dividida, pois nesse caso a tela
 a nova janela aparece à esquerda da atual. Para que ela apareça à
 direita:
 ```
-:set splitright .... a janela nova abre à direita da atual
+set splitright
 ```

--- a/docs/capitulo_8/repeticao_de_comandos.md
+++ b/docs/capitulo_8/repeticao_de_comandos.md
@@ -43,10 +43,11 @@ Se desejássemos digitar 10 linhas com o texto
 isto é um teste
 ```
 deveríamos então fazer assim:
-```
-<Esc> .. para ter certeza que ainda estamos no modo normal
-10 ..... quantificador antes
-i ...... entrar no modo de inserção
-isto é um teste <Enter>
-<Esc> .. voltar ao modo normal
-```
+
+| Comando | Descrição |
+|---------|-----------|
+| `<Esc>` | para ter certeza que ainda estamos no modo normal |
+| `10` | quantificador antes |
+| `i` | entrar no modo de inserção |
+| `isto é um teste <Enter>` | digita o texto |
+| `<Esc>` | voltar ao modo normal |

--- a/docs/capitulo_8/repetindo_a_digitacao_de_uma_linha.md
+++ b/docs/capitulo_8/repetindo_a_digitacao_de_uma_linha.md
@@ -2,12 +2,13 @@
 title: Repetindo a digitação de uma linha
 ---
 
-```
-modo de inserção
-Ctrl-y .......... repete a linha acima
-Ctrl-e .......... repete a linha abaixo
-Ctrl-x Ctrl-l ... repete linhas completas
-```
+No modo de inserção:
+
+| Comando | Descrição |
+|---------|-----------|
+| `Ctrl-y` | repete a linha acima |
+| `Ctrl-e` | repete a linha abaixo |
+| `Ctrl-x Ctrl-l` | repete linhas completas |
 O atalho **Ctrl-x Ctrl-l** só funcionará para uma linha
 semelhante, experimente digitar:
 ```

--- a/docs/capitulo_9/comandos_externos.md
+++ b/docs/capitulo_9/comandos_externos.md
@@ -3,13 +3,13 @@ Comandos Externos
 
 O Vim permite executar comandos externos para processar ou filtrar o
 conteúdo de um arquivo. De forma geral, fazemos isso digitando (no modo
-normal):
+normal) o comando abaixo, que visualiza o conteúdo do diretório:
 ```
-:!ls .... visualiza o conteúdo do diretório
+:!ls
 ```
 Lembrando que anexando um simples ponto, a saída do comando torna-se o
 documento que está sendo editado:
 ```
-:.!ls .... imprime na tela o conteúdo do diretório
+:.!ls
 ```
 A seguir, veja alguns exemplos de utilização:

--- a/docs/capitulo_9/ordenando.md
+++ b/docs/capitulo_9/ordenando.md
@@ -1,7 +1,7 @@
 Podemos usar o comando *sort* que ordena o conteúdo de um
 arquivo dessa forma:
 ```
-:5,15!sort ..... ordena da linha 5 até a linha 15
+:5,15!sort
 ```
 O comando acima ordena da linha 5 até a linha 15.
 


### PR DESCRIPTION
Resolve #47.

O commit 0670bb4 converteu parte das listas de referência herdadas do PDF original. Este MR termina o trabalho: **43 arquivos** ainda tinham blocos de código que eram, na verdade, listas comando → descrição, exibindo um botão de copiar sem sentido.

Exemplo do caso citado na issue, <https://vimbook.com.br/capitulo_3/movendo-se_no_documento/>, que sozinho tinha 36 linhas nesse formato.

## Critério aplicado

Segui o mesmo critério do commit original, confirmado ao olhar como ele tratou `capitulo_2/edicao_avancada_de_linhas.md`:

- **Lista de referência e anatomia de comando** → tabela `| Comando | Descrição |`. A issue levantava a dúvida se os blocos de "anatomia" deveriam ser convertidos; o commit anterior já os convertia, então segui o precedente.
- **Comando real para digitar** → continua bloco de código, com cópia. Quando a descrição estava colada no comando (`:5,15!sort ..... ordena da linha 5 até a linha 15`), ela passou para o texto ao redor e o bloco ficou só com o comando.
- **Blocos mistos** foram separados: em `capitulo_6/exemplos.md`, por exemplo, um único bloco tinha um comando de busca, a anatomia dele e uma lista de outras substituições — virou bloco de código + duas tabelas.

## Escopo além da issue

A tabela da issue listava 24 arquivos, filtrados por 3 ou mais linhas no padrão. Ao varrer sem esse corte apareceram mais 19 com o mesmo defeito em 1 ou 2 linhas, e incluí todos — deixá-los de fora manteria o problema pela metade.

## Armadilha encontrada: pipe dentro de célula

O comando `10|` (ir para a coluna 10) e a descrição de `<bar>` precisam exibir um pipe literal, que é justamente o separador de células. Usei `\|`, a forma do GFM, e **não funcionou** — o parser do zensical não é GFM e renderizava o barra-invertida literalmente:

```
<code>10\|</code>
```

Testei a alternativa com uma página descartável e confirmei que `<code>&#124;</code>` funciona, enquanto `` `10&#124;` `` não (a entidade é escapada dentro das crases):

```
<td><code>10&amp;#124;</code></td>   <- backtick: errado
<td><code>10&#124;</code></td>       <- HTML: correto
```

Vale saber para futuras tabelas. Varri o site atrás de outras ocorrências: as duas restantes em `outros_mapeamentos.md` e `exemplos.md` estão certas, porque ali `\|` é mesmo o operador de alternância do Vim.

## Verificação

```
$ uvx --from zensical zensical build
No issues found

$ # nenhum bloco no padrão "chave ..... descrição" restante
$ # nenhuma cerca de código desbalanceada nos 179 arquivos
```

Confirmei também que as tabelas saem como tabelas de verdade — a página do capítulo 3 gera 7 tabelas (a maior com 24 linhas) e mantém 11 blocos de código, que são os comandos para digitar. O site tem agora 123 tabelas.

## Correções de conteúdo que vieram junto

Ao reescrever as linhas, três descrições erradas ficaram evidentes e foram corrigidas:

- `H` — "posiciona o cursor no primeiro caractere da tela" → "na primeira linha da tela"
- `zC` — "fecha a dobra abaixo do cursor" → "sob o cursor"
- A anatomia de `/^.\{,30\}$` explicava só `^` e `.`; como tabela a lacuna ficava evidente, então incluí `\{,30\}` e `$`