### PR TITLE
Corrige tabelas que absorveram o parágrafo seguinte

### DIFF
--- a/docs/capitulo_12/autocomandos.md
+++ b/docs/capitulo_12/autocomandos.md
@@ -64,6 +64,7 @@ Explicação para o autocomando acima:
 | `\t` | tabulação |
 | `\+` | uma vez ou mais |
 | `/` | fim do padrão de buscas |
+
 Para evitar que este erro se repita, ou seja, que sejam adicionados no
 começo de linha espaços no lugar de tabulações adiciona-se ao \~/.vimrc
 ```

--- a/docs/capitulo_12/criando_um_menu.md
+++ b/docs/capitulo_12/criando_um_menu.md
@@ -11,6 +11,7 @@ O comando acima diz:
 | `amenu` | cria um menu |
 | `Ferramentas.ExibirNomeDoTema` | menu Ferramentas, submenu ExibirNomeDoTema |
 | `:echo g:colors_name<cr>` | exibe o nome do tema atual |
+
 Caso haja espaços no nome a definir você pode fazer assim
 ```
 amenu Ferramentas.Exibir\ nome\ do\ tema :echo g:colors_name<cr>

--- a/docs/capitulo_14/nao_digite_duas_vezes.md
+++ b/docs/capitulo_14/nao_digite_duas_vezes.md
@@ -29,6 +29,7 @@ Para um trecho muito copiado coloque o seu conteúdo em um registrador:
 |---------|-----------|
 | `"ayy` | copia a linha atual para o registrador `a' |
 | `"ap` | cola o registrador `a' |
+
 Crie abreviações para erros comuns no seu arquivo de configuração
 (`~/.vimrc`):
 

--- a/docs/capitulo_6/exemplos.md
+++ b/docs/capitulo_6/exemplos.md
@@ -75,6 +75,7 @@ Outras substituições úteis:
 | `:%s/<[^>]*>//g` | apaga tags HTML/XML |
 | `:%g/^$/d` | apaga linhas vazias |
 | `:%s/^[\ \t]*\n//g` | apaga linhas vazias |
+
 Remover duas ou mais linhas vazias entre parágrafos diminuindo para uma
 só linha vazia.
 ```

--- a/docs/capitulo_6/usando_expressoes_regulares_em_buscas.md
+++ b/docs/capitulo_6/usando_expressoes_regulares_em_buscas.md
@@ -61,6 +61,7 @@ Explicação do comando acima:
 | `{3}` | três vezes |
 | `/` | inicio da substituição |
 | `\1` | referencia o grupo 1 |
+
 Analisando o exemplo anterior, a linha de raciocínio foi a de “manter o
 texto entre os dígitos”, o que pode ser traduzido, em uma outra forma de
 raciocínio, como “remover os dígitos”.
@@ -79,6 +80,7 @@ Explicação do comando acima:
 | `/` | substituir por |
 | vazio | exato, substituir por vazio |
 | `/g` | a substituição se torna global |
+
 A opção `g` — de *global* — faz a substituição valer para todas as
 ocorrências do padrão em cada linha. Sem ela, apenas a primeira
 ocorrência de cada linha é substituída.
@@ -117,6 +119,7 @@ Explicando o comando acima:
 | `/` | inicia substituição |
 | `\U` | para maiúsculo |
 | `&` | corresponde ao que foi buscado |
+
 Nem todas as classes *POSIX* conseguem pegar caracteres
 acentuados, portanto deve-se habilitar o destaque colorido para buscas
 usando:

--- a/docs/capitulo_8/repetindo_a_digitacao_de_uma_linha.md
+++ b/docs/capitulo_8/repetindo_a_digitacao_de_uma_linha.md
@@ -9,6 +9,7 @@ No modo de inserção:
 | `Ctrl-y` | repete a linha acima |
 | `Ctrl-e` | repete a linha abaixo |
 | `Ctrl-x Ctrl-l` | repete linhas completas |
+
 O atalho **Ctrl-x Ctrl-l** só funcionará para uma linha
 semelhante, experimente digitar:
 ```


### PR DESCRIPTION
Regressão introduzida por mim em #53, já em `main` e visível no site publicado.

## O problema

Em 8 pontos a tabela ficou encostada no parágrafo seguinte, sem linha em branco entre os dois. O parser do zensical continua lendo as linhas como parte da tabela, então o parágrafo era renderizado **dentro** dela, quebrado em uma célula por linha do arquivo fonte:

```html
<td>fim do padrão de buscas</td>
</tr>
<tr>
<td>Para evitar que este erro se repita, ou seja, que sejam adicionados no</td>
<td></td>
</tr>
<tr>
<td>começo de linha espaços no lugar de tabulações adiciona-se ao \~/.vimrc</td>
```

Depois da correção o parágrafo volta para fora:

```html
<td>fim do padrão de buscas</td>
</tr>
</tbody>
</table>
<p>Para evitar que este erro se repita, ou seja, que sejam adicionados no
começo de linha espaços</p>
```

## Páginas afetadas

- `capitulo_6/exemplos.md`
- `capitulo_6/usando_expressoes_regulares_em_buscas.md` (3 ocorrências)
- `capitulo_8/repetindo_a_digitacao_de_uma_linha.md`
- `capitulo_12/autocomandos.md`
- `capitulo_12/criando_um_menu.md`
- `capitulo_14/nao_digite_duas_vezes.md`

## Por que passou despercebido

O `zensical build` responde `No issues found` nos dois casos — para ele é uma tabela válida, só que com linhas a mais. Meu conferimento no #53 checou se as tabelas tinham virado tabelas de verdade e se as cercas de código estavam balanceadas, mas não o que vinha logo depois delas. Passei a varrer o padrão diretamente no fonte:

```
$ # linha que começa com | seguida de linha não vazia que não começa com |
$ tabelas coladas restantes: 0
```

Vale como verificação padrão em qualquer MR que mexa em tabelas.