### PR TITLE
Documenta a convenção de tabelas de comandos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ O site fica disponível em <http://localhost:8000> e recarrega automaticamente a
 
 ## Convenções utilizadas e dicas
 
-* Não utilize emojis de forma textual `:emoji:`, copie do [emojipédia](https://emojipedia.org/pt) o invés;
+* Não utilize emojis de forma textual `:emoji:`, copie do [emojipédia](https://emojipedia.org/pt) ao invés;
 * Todo título de seção é iniciado com um emoji;
 * Novos capítulos devem ser adicionados também no menu de navegação (`nav`) que se encontra no arquivo `zensical.toml`;
 * Páginas cujo título não começa com um cabeçalho `#` precisam declarar o título no *front matter*, por exemplo:
@@ -100,3 +100,31 @@ O site fica disponível em <http://localhost:8000> e recarrega automaticamente a
 title: Instalação do vim
 ---
 ```
+
+### Tabelas de comandos
+
+Listas de referência — comando de um lado, descrição do outro — vão em
+tabelas, não em blocos de código. Blocos de código são reservados para
+comandos que a pessoa vai de fato digitar, porque só eles fazem sentido
+com o botão de copiar:
+
+```
+| Comando | Descrição |
+|---------|-----------|
+| `gg` | vai para o início do arquivo |
+```
+
+Dois detalhes que geram erro silencioso, porque o `zensical build`
+aceita os dois casos sem reclamar:
+
+* **Deixe uma linha em branco depois da tabela.** Sem ela, o parser
+  continua lendo o parágrafo seguinte como linhas da tabela, e o texto
+  aparece dentro dela, quebrado em uma célula por linha do arquivo.
+
+* **Para exibir uma barra vertical dentro de uma célula, use
+  `<code>&#124;</code>`.** O `\|` do GitHub não funciona aqui: o parser
+  não é GFM e mostra a barra invertida na tela. Dentro de crases a
+  entidade também não resolve, porque é escapada — só funciona com a
+  tag `<code>` escrita à mão. Isso vale para comandos como `10|` (ir
+  para a coluna 10); já o `\|` das expressões regulares do Vim, que é o
+  operador de alternância, deve mesmo aparecer com a barra invertida.


### PR DESCRIPTION
Registra no `CONTRIBUTING.md` a convenção que os MRs #53 e #54 aplicaram na prática, para não se perder.

## O que documenta

1. **Listas de referência vão em tabela, não em bloco de código.** Bloco de código é para comando que se digita — é o que justifica o botão de copiar. Foi o critério do commit 0670bb4 e do #53, mas não estava escrito em lugar nenhum.

2. **Linha em branco depois da tabela.** Sem ela o parágrafo seguinte é absorvido como linhas da tabela. Foi exatamente a regressão do #54.

3. **Barra vertical dentro de célula usa `<code>&#124;</code>`.** O `\|` do GitHub não funciona neste parser, e dentro de crases a entidade é escapada. Anotei também a exceção: o `\|` das expressões regulares do Vim é o operador de alternância e deve mesmo aparecer com a barra invertida — quem for "corrigir" isso depois vai quebrar as tabelas de `outros_mapeamentos.md` e `exemplos.md`.

O ponto comum dos itens 2 e 3 é que **o `zensical build` responde `No issues found` nos dois casos** — não há como o CI pegar, então precisa estar escrito.

## Fora do escopo

Corrigi um "o invés" → "ao invés" que estava numa linha vizinha, já que estava editando o arquivo. Se preferir separar, eu tiro.