### PR TITLE
Atualiza links externos quebrados e desatualizados

### DIFF
--- a/docs/capitulo_1/instalacao_do_vim.md
+++ b/docs/capitulo_1/instalacao_do_vim.md
@@ -6,7 +6,7 @@ title: Instalação do vim
 
 Há uma versão gráfica do Vim disponível para vários sistemas
 operacionais, incluindo o Windows; esta versão pode ser encontrada no
-[site oficial](http://www.vim.org/download.php).
+[site oficial](https://www.vim.org/download.php).
 Para instalá-lo basta baixar o instalador no link indicado e dispará-lo
 com um duplo clique (este procedimento requer privilégios de
 administrador).
@@ -38,14 +38,14 @@ distribuição. A forma de instalação preferível depende da distribuição:
 -   Não estar disponível no repositório da distribuição – cenário
     *muito* improvável, mas nas sua ocorrência o Vim pode
     ser instalado através da compilação do código-fonte; basta seguir as
-    instruções do [site oficial](http://www.vim.org/download.php).
+    instruções do [site oficial](https://www.vim.org/download.php).
 
-    [^1]: Debian GNU/Linux - <http://www.debian.org/index.pt.html>
+    [^1]: Debian GNU/Linux - <https://www.debian.org/index.pt.html>
 
     [^2]: Recomenda-se também instalar a documentação em HTML do Vim: `apt-get install vim-doc`
 
     [^3]: Para ubuntu e Debian
 
-    [^4]: O Python (<http://www.python.org>) é uma linguagem de programação orientada a objetos muito comum no meio profissional e acadêmico
+    [^4]: O Python (<https://www.python.org>) é uma linguagem de programação orientada a objetos muito comum no meio profissional e acadêmico
 
 

--- a/docs/capitulo_1/introducao.md
+++ b/docs/capitulo_1/introducao.md
@@ -43,7 +43,7 @@ contrapartida, o usuário deve aprender como pré-configurar o editor. O
 que requer esforço para aprender a utilizar o programa escolhido. O
 benefício somente será observado a médio/longo prazo, quando o tempo
 ganho ao utilizar a configuração será superior ao tempo consumido
-aprendendo sobre o programa. O “[Vim](http://www.vim.org)”[^1] é um
+aprendendo sobre o programa. O “[Vim](https://www.vim.org)”[^1] é um
 editor de texto extremamente configurável, criado para permitir a edição
 de forma eficiente, tornando-a produtiva e confortável. Também é uma
 aprimoração do editor “Vi”, um tradicional programa dos sistemas Unix.
@@ -68,10 +68,10 @@ Emacs[^3], um dos editores mais usados nos sistemas GNU/Linux[^4],
 embora esteja também disponível em outros sistemas, como o Windows e o
 Macintosh.
 
-[^1]: Vim - <http://www.vim.org>
+[^1]: Vim - <https://www.vim.org>
 
-[^2]: Expressões Regulares - <http://guia-er.sourceforge.net/guia-er.html>
+[^2]: Expressões Regulares - <https://aurelio.net/regex/guia/>
 
-[^3]: Emacs - <http://www.gnu.org/software/emacs/>
+[^3]: Emacs - <https://www.gnu.org/software/emacs/>
 
 [^4]: O kernel Linux sem os programas GNU não serviria para muita coisa.

--- a/docs/capitulo_10/dicionario_de_termos.md
+++ b/docs/capitulo_10/dicionario_de_termos.md
@@ -28,7 +28,7 @@ início de 2009.
 
 A instalação envolve três passos, são eles:
 
-1.  obtenção do dicionário através do site BrOffice.org;
+1.  obtenção do dicionário através do site do LibreOffice;
 
 2.  conversão para o formato interno de dicionário do Vim; e
 
@@ -36,7 +36,7 @@ A instalação envolve três passos, são eles:
 
 #### Obtenção do dicionário
 
-O dicionário pode ser obtido no [site do libreoffice](https://pt-br.libreoffice.org/projetos/vero#baixarvero).
+O dicionário pode ser obtido no [site do libreoffice](https://extensions.libreoffice.org/en/extensions/show/vero-verificador-ortografico-e-hifenizador-em-portugues-do-brasil).
 O arquivo baixado encontra-se compactado no formato oxt,
 bastando portanto descompactá-lo com qualquer utilitário compatível com
 este formato, por exemplo, o comando unzip.

--- a/docs/capitulo_12/autocomandos.md
+++ b/docs/capitulo_12/autocomandos.md
@@ -13,7 +13,7 @@ No exemplo acima o Vim aplica autocomandos para arquivos novos
 terminados em `txt`, e para estes tipos carrega um arquivo de
 **syntax**, ou seja, um esquema de cores específico.
 ```
-" http://aurelio.net/doc/vim/txt.vim    coloque em ~/.vim/syntax
+" https://aurelio.net/vim/txt.vim    coloque em ~/.vim/syntax
 au BufNewFile,BufRead *.txt source ~/.vim/syntax/txt.vim
 ```
 Para arquivos do tipo texto ‘*.txt*’ use um arquivo de

--- a/docs/capitulo_12/como_adicionar_o_python_ao_path_do_vim.md
+++ b/docs/capitulo_12/como_adicionar_o_python_ao_path_do_vim.md
@@ -3,7 +3,7 @@ title: Como adicionar o Python ao path do Vim?
 ---
 
 Coloque o seguinte
-[script](http://vim.wikia.com/wiki/Automatically_add_Python_paths_to_Vim_path)
+[script](https://vim.fandom.com/wiki/Automatically_add_Python_paths_to_Vim_path)
 em:
 
 -   `~/.vim/after/ftplugin/python.vim` (em sistemas Unix)

--- a/docs/capitulo_12/evitando_arquivos_de_backup_no_disco.md
+++ b/docs/capitulo_12/evitando_arquivos_de_backup_no_disco.md
@@ -14,5 +14,5 @@ set nobackup
 set writebackup
 ```
 Fonte: [Site do Eustáquio
-Rangel](http://eustaquiorangel.com/posts/520).
+Rangel](https://eustaquiorangel.com/posts/520).
 

--- a/docs/capitulo_12/funcoes.md
+++ b/docs/capitulo_12/funcoes.md
@@ -51,7 +51,7 @@ set statusline+=[POS=%04l,%04v][%p%%][LEN=%L]
 set laststatus=2
 ```
 Caso este código não funcione acesse [este
-link](http://vim.wikia.com/wiki/Writing_a_valid_statusline) 
+link](https://vim.fandom.com/wiki/Writing_a_valid_statusline) 
 
 ### Rolar outra janela
 
@@ -79,7 +79,7 @@ Esta função é acionada com o atalho *Alt-⬆* e
 ### Função para numerar linhas
 
 No site wikia há um código de função para [numerar
-linhas](http://vim.wikia.com/wiki/Number_a_group_of_lines) 
+linhas](https://vim.fandom.com/wiki/Number_a_group_of_lines) 
 
 ### Função para trocar o esquema de cores
 ```VimL

--- a/docs/capitulo_12/mantendo_apenas_um_gvim_aberto.md
+++ b/docs/capitulo_12/mantendo_apenas_um_gvim_aberto.md
@@ -44,6 +44,6 @@ corrente do Gvim, em uma nova aba, por exemplo:
 ```
 tvim .vimrc
 ```
-Fonte: [Site do Eustáquio Rangel](http://eustaquiorangel.com/posts/477) 
+Fonte: [Site do Eustáquio Rangel](https://eustaquiorangel.com/posts/477) 
 
 [^1]: Diretórios nos quais o sistema busca pelos comandos

--- a/docs/capitulo_12/mapeamentos.md
+++ b/docs/capitulo_12/mapeamentos.md
@@ -162,7 +162,7 @@ imap <s-f1> <space><esc>"myBEa=<c-r>=<c-r>m<enter><del>
 Para efetuar cálculos com maior precisão e também resolver problemas
 como potências raízes, logaritmos pode-se mapear comandos externos, como
 a biblioteca matemática da linguagem de programação Python.
-[Neste link](http://vim.wikia.com/wiki/Scientific_calculator)
+[Neste link](https://vim.fandom.com/wiki/Scientific_calculator)
 há um manual que ensina a realizar este procedimento, ou acesse o
 capítulo [Uma calculadora diferente](../capitulo_2/uma_calculadora_diferente.md).
 

--- a/docs/capitulo_12/outros_mapeamentos.md
+++ b/docs/capitulo_12/outros_mapeamentos.md
@@ -45,4 +45,4 @@ nmap <S-F2> A<Del><Space>
 ```
 Para mais detalhes sobre buscas acesse o capítulo [Buscas e substituições](../capitulo_6/buscas_e_substituicoes.md).
 
-[^1]: <http://guia-er.sourceforge.net>
+[^1]: <https://aurelio.net/regex/guia/>

--- a/docs/capitulo_12/referencias.md
+++ b/docs/capitulo_12/referencias.md
@@ -2,6 +2,6 @@
 title: Referências
 ---
 
--  [http://www.dicas-l.com.br/dicas-l/20050118.php](http://www.dicas-l.com.br/dicas-l/20050118.php)
+-  [https://www.dicas-l.com.br/arquivo/vim_opcoes_uteis_de_configuracao.php](https://www.dicas-l.com.br/arquivo/vim_opcoes_uteis_de_configuracao.php)
 
 

--- a/docs/capitulo_13/uma_wiki_para_o_vim.md
+++ b/docs/capitulo_13/uma_wiki_para_o_vim.md
@@ -4,7 +4,7 @@ Um Wiki para o Vim
 É inegável a facilidade que um Wiki nos traz, os documentos são
 indexados e linkados de forma simples. Já pesquisei uma porção de Wikis
 e, para uso pessoal recomendo o Potwiki. O “link” do Potwiki é
-[este](http://www.vim.org/scripts/script.php?script_id=1018). 
+[este](https://www.vim.org/scripts/script.php?script_id=1018). 
 O Potwiki é um Wiki completo para o Vim, funciona localmente embora
 possa ser aberto remotamente via ssh[^1]. Para criar um “link” no
 Potwiki basta usar WikiNames, são nomes iniciados com letra maiúscula e

--- a/docs/capitulo_14/habitos_para_edicao_efetiva.md
+++ b/docs/capitulo_14/habitos_para_edicao_efetiva.md
@@ -12,4 +12,4 @@ por Bram Moolenaar em seu artigo.
 
 [^1]: http://www.moolenaar.net
 
-[^2]: http://br-linux.org/linux/7-habitos-da-edicao-de-texto-efetiva
+[^2]: https://br-linux.org/linux/7-habitos-da-edicao-de-texto-efetiva

--- a/docs/capitulo_14/referencias.md
+++ b/docs/capitulo_14/referencias.md
@@ -4,4 +4,4 @@ title: Referências
 
 -   <http://www.moolenaar.net/habits_2007.pdf> por Bram Moolenaar
 
--   <http://vim.wikia.com/wiki/Did_you_know>
+-   <https://vim.fandom.com/wiki/Did_you_know>

--- a/docs/capitulo_15/acessando_documentacao_do_python_no_vim.md
+++ b/docs/capitulo_15/acessando_documentacao_do_python_no_vim.md
@@ -3,5 +3,5 @@ title: Acessando documentação do Python no Vim
 ---
 
 Obtenha um plugin para esta tarefa em seu
-[site oficial](http://www.vim.org/scripts/script.php?script_id=910).
+[site oficial](https://www.vim.org/scripts/script.php?script_id=910).
 

--- a/docs/capitulo_15/complementacao_de_codigo.md
+++ b/docs/capitulo_15/complementacao_de_codigo.md
@@ -10,14 +10,14 @@ os chamados modelos ou *templates*. Insere um trecho de código pronto,
 mas vai além disso, permitindo saltar para trechos do modelo inserido
 através de um atalho configurável de modo a agilizar o trabalho do
 programador.
-[Link para baixar](http://www.vim.org/scripts/script.php?script_id=1318).
+[Link para baixar](https://www.vim.org/scripts/script.php?script_id=1318).
 
 ### Instalação
 Um artigo ensinando como instalar o "*plugin*" snippetsEmu pode ser lido
-[neste link](http://vivaotux.blogspot.com/2008/03/instalando-o-plugin-snippetsemu-no-vim.html).
+[neste link](https://vivaotux.blogspot.com/2008/03/instalando-o-plugin-snippetsemu-no-vim.html).
 Outro plugin muito interessante para complementação é o "autocompletepopup"
 que complementa mostrando um popup durante a digitação, o mesmo pode ser obtido
-[neste link](http://www.vim.org/scripts/script.php?script_id=1879),
+[neste link](https://www.vim.org/scripts/script.php?script_id=1879),
 em seguida coloca-se esta linha ao vimrc:
 
 ```

--- a/docs/capitulo_15/formatando_textos_planos_com_syntax.md
+++ b/docs/capitulo_15/formatando_textos_planos_com_syntax.md
@@ -1,3 +1,3 @@
 Um plugin que adiciona sintaxe colorida a textos planos pode ser obtido
-[neste link](http://www.vim.org/scripts/script.php?script_id=2208&rating=helpful#1.3).
+[neste link](https://www.vim.org/scripts/script.php?script_id=2208&rating=helpful#1.3).
 Veja como instalar o este plugin no capítulo [Um wiki para o Vim](../capitulo_13/uma_wiki_para_o_vim.md).

--- a/docs/capitulo_15/movimentando_em_camel_case.md
+++ b/docs/capitulo_15/movimentando_em_camel_case.md
@@ -5,8 +5,8 @@ title: Movimentando em CamelCase
 Movimentando em *camel case*
 ----------------------------
 
-O *plugin* [CamelCaseMotion](http://www.vim.org/scripts/script.php?script_id=1905) auxilia a navegação em palavras em
-[*camel case*](http://en.wikipedia.org/wiki/Camel_case) ou separadas
+O *plugin* [CamelCaseMotion](https://www.vim.org/scripts/script.php?script_id=1905) auxilia a navegação em palavras em
+[*camel case*](https://en.wikipedia.org/wiki/Camel_case) ou separadas
 por sublinhados, através de mapeamentos similares aos que fazem a movimentação
 normal entre strings, e é um recurso de grande ajuda quando o editor é
 utilizado para programação.
@@ -16,4 +16,4 @@ Após instalado o plugin, os seguintes atalhos ficam disponíveis:
 * **,b** Movimenta para a posição *camel* anterior dentro da string
 * **,e** Movimenta para o caractere anterior à próxima posição *camel* dentro da string
 
-Fonte: [Blog do EustáquioRangel](http://eustaquiorangel.com/posts/522)
+Fonte: [Blog do EustáquioRangel](https://eustaquiorangel.com/posts/522)

--- a/docs/capitulo_15/o_plugin_auto_complete.md
+++ b/docs/capitulo_15/o_plugin_auto_complete.md
@@ -5,5 +5,5 @@ title: O Plugin AutoComplete
 Este plugin trabalha exibindo sugestões no modo de inserção, à
 medida que o usuário digita aparece um *popup* com sugestões para possíveis
 complementos, bastando pressionar `<Enter>` para aceitar as sugestões.
-Neste [link](http://www.vim.org/scripts/script.php?script_id=1879), você pode
+Neste [link](https://www.vim.org/scripts/script.php?script_id=1879), você pode
 fazer o *download* do plugin.

--- a/docs/capitulo_15/o_plugin_ctags.md
+++ b/docs/capitulo_15/o_plugin_ctags.md
@@ -32,9 +32,9 @@ Assim você pode copiar o arquivo de tags para todos os diretórios e mesmo
 assim conseguir usar os atalhos do plugin para navegar no código fonte.
 
 Pode-se obter o programa *Ctags* neste
-[link](http://ctags.sourceforge.net/).
+[link](https://ctags.io/).
 O plugin de *Ctags* para o Vim está neste
-[link](http://vim.sourceforge.net/scripts/script.php?script_id=12),
+[link](https://www.vim.org/scripts/script.php?script_id=12),
 e para instalá-lo basta copiá-lo para a pasta apropriada:
 
 | Comando | Descrição |

--- a/docs/capitulo_15/o_plugin_easy_grep.md
+++ b/docs/capitulo_15/o_plugin_easy_grep.md
@@ -20,7 +20,7 @@ Mas no caso do plugin *EasyGrep* fica assim:
 | `:GrepOptions` | exibe as opções de uso do plugin |
 
 O plugin pode ser obtido no seguinte
-[link](http://www.vim.org/scripts/script.php?script_id=2438#0.9).
+[link](https://www.vim.org/scripts/script.php?script_id=2438#0.9).
 Já sua instalação é simples, basta copiar o arquivo obtido no link acima
 para a pasta:
 
@@ -30,7 +30,7 @@ para a pasta:
 | `~/vimfiles/plugin` | no caso do windows |
 
 Um vídeo de exemplo (na verdade uma animação gif) pode ser visto
-[aqui](http://downloads.veryspeedy.net/vim/EasyGrep.gif).
+[aqui](https://github.com/dkprice/vim-easygrep#screencast).
 
 
 [^1]: Sistemas da família Unix tipo o GNU/Linux

--- a/docs/capitulo_15/o_plugin_findmate.md
+++ b/docs/capitulo_15/o_plugin_findmate.md
@@ -3,7 +3,7 @@ title: O Plugin FindMate
 ---
 
 Um plugin que agiliza a busca por arquivos na pasta pessoal,
-disponível neste [link](http://snipt.net/voyeg3r/findmate-plugin-for-vim/).
+disponível neste [link](https://web.archive.org/web/20161102021305/https://snipt.net/voyeg3r/findmate-plugin-for-vim/).
 Basta colocá-lo na pasta `/home/usuario/.vim/plugins/` e digitar duas vezes
 vírgula e ele substituirá para:
 

--- a/docs/capitulo_15/o_plugin_project.md
+++ b/docs/capitulo_15/o_plugin_project.md
@@ -3,7 +3,7 @@ title: O Plugin Project
 ---
 
 O plugin project acessível através deste
-[link](http://www.vim.org/scripts/script.php?script_id=69)
+[link](https://www.vim.org/scripts/script.php?script_id=69)
 cria toda uma estrutura de gerenciamento de projetos.
 Para programadores é uma funcionalidade extremamente necessária.
 Costuma-se trabalhar com vários arquivos da mesma família ("extensão"),

--- a/docs/capitulo_15/o_plugin_pydiction.md
+++ b/docs/capitulo_15/o_plugin_pydiction.md
@@ -23,4 +23,4 @@ if has("autocmd")
 endif " has("autocmd")
 ```
 
-Pode-se obter o plugin  [neste link](http://www.vim.org/scripts/script.php?script_id=850).
+Pode-se obter o plugin  [neste link](https://www.vim.org/scripts/script.php?script_id=850).

--- a/docs/capitulo_15/o_plugin_search_complete.md
+++ b/docs/capitulo_15/o_plugin_search_complete.md
@@ -16,7 +16,7 @@ o mesmo início, por exemplo:
 Cada vez que se pressiona a tecla `<tab>` o cursor saltará para
 a próxima ocorrência daquele fragmento de palavra.
 Pode-se obter o plugin *SearchComplete* no seguinte
-[link](http://www.vim.org/scripts/script.php?script_id=474),
+[link](https://www.vim.org/scripts/script.php?script_id=474),
 e para instalá-lo basta copiá-lo para a pasta apropriada:
 
 | Comando | Descrição |
@@ -25,4 +25,4 @@ e para instalá-lo basta copiá-lo para a pasta apropriada:
 | `~/.vim/plugin` | no Gnu/Linux |
 
 Há outro plugin similar chamado `CmdlineComplete` disponível
-[neste link](http://www.vim.org/scripts/script.php?script_id=2222).
+[neste link](https://www.vim.org/scripts/script.php?script_id=2222).

--- a/docs/capitulo_15/plugin_fuzzyfinder.md
+++ b/docs/capitulo_15/plugin_fuzzyfinder.md
@@ -13,8 +13,8 @@ Sua proposta é acessar de forma rápida:
 6. Tags `:FuzzyFinderTag`
 
 Para ver o plugin em ação acesse este
-[video](http://vimeo.com/2938498) e para obtê-lo acesse
- [este link](http://www.vim.org/scripts/script.php?script_id=1984),
+[video](https://vimeo.com/2938498) e para obtê-lo acesse
+ [este link](https://www.vim.org/scripts/script.php?script_id=1984),
 para instalá-lo basta copiar para o diretório `~/.vim/plugin`.
 
 [^1]: Editor de textos da Apple com muitos recursos

--- a/docs/capitulo_15/plugin_para_latex.md
+++ b/docs/capitulo_15/plugin_para_latex.md
@@ -3,7 +3,7 @@ title: Plugin para LaTeX
 ---
 
 Um plugin completo para *LaTeX* está acessível
-[aqui](http://vim-latex.sourceforge.net).
+[aqui](https://vim-latex.sourceforge.net).
 Uma vez adicionado o plugin você pode inserir seus *templates* em:
 
 ```

--- a/docs/capitulo_15/plugin_para_manipular_arquivos.md
+++ b/docs/capitulo_15/plugin_para_manipular_arquivos.md
@@ -1,4 +1,5 @@
 Acesse o plugin neste
-[link](http://www.vim.org/scripts/script.php?script_id=2337#0.1.9).
-Para entender este plugin acesse um vídeo
-[neste link](http://www.screencast.com/t/P6nJkJ0DE)
+[link](https://www.vim.org/scripts/script.php?script_id=2337#0.1.9).
+O vídeo de demonstração que acompanhava o plugin não está mais disponível,
+mas o código e a documentação estão no
+[repositório do plugin](https://github.com/kana/vim-ku).

--- a/docs/capitulo_15/plugins.md
+++ b/docs/capitulo_15/plugins.md
@@ -3,7 +3,7 @@ Plugins
 *"Plugins"*[^1] são um meio de estender as funcionalidades do Vim,
 há "plugins" para diversas tarefas, desde wikis para o Vim até
 ferramentas de auxílio a navegação em arquivos com é o caso do *"plugin"*
-[NerdTree](http://www.vim.org/scripts/script.php?script_id=1658), que
+[NerdTree](https://www.vim.org/scripts/script.php?script_id=1658), que
 divide uma janela que permite navegar pelos diretórios do sistema a fim de
 abrir arquivos a serem editados.
 

--- a/docs/capitulo_5/referencias.md
+++ b/docs/capitulo_5/referencias.md
@@ -2,9 +2,9 @@
 title: Referências
 ---
 
--   <http://rayninfo.co.uk/vimtips.html>
+-   <https://web.archive.org/web/20260603225804/http://www.rayninfo.co.uk/vimtips.html>
 
--   <http://aprendolatex.wordpress.com>
+-   <https://aprendolatex.wordpress.com>
 
--   <http://pt.wikibooks.org/wiki/Latex>
+-   <https://pt.wikibooks.org/wiki/Latex>
 

--- a/docs/capitulo_5/registrador_de_expressoes.md
+++ b/docs/capitulo_5/registrador_de_expressoes.md
@@ -12,7 +12,7 @@ status e o usuário digita então uma expressão matemática como uma
 multiplicação "6\*9" e em seguida pressiona
 Enter para que o editor finalize a operação. Veja um vídeo
 demonstrando sua utilização [neste
-link](http://vimeo.com/2967392).
+link](https://vimeo.com/2967392).
 
 Para entender melhor como funciona o registrador de expressões tomemos um
 exemplo. Para fazer uma sequência como abaixo:

--- a/docs/capitulo_6/buscando_em_um_intervalo_de_linhas.md
+++ b/docs/capitulo_6/buscando_em_um_intervalo_de_linhas.md
@@ -3,4 +3,4 @@ Para buscar entre as linhas 10 e 50 por um padrão qualquer fazemos:
 /\%>10l\%<50l padrao
 ```
 Esta e outras boas dicas podem ser lidas no site
-[vim-faq](http://vimdoc.sourceforge.net/htmldoc/vimfaq.html).
+[vim-faq](https://vimhelp.org/vim_faq.txt.html).

--- a/docs/capitulo_6/dicas_da_lista_vi-br.md
+++ b/docs/capitulo_6/dicas_da_lista_vi-br.md
@@ -2,7 +2,9 @@
 title: Dicas da lista vi-br
 ---
 
-Fonte: [Grupo vi-br do yahoo](http://groups.yahoo.com/group/vi-br/message/853)
+Fonte: Grupo vi-br do Yahoo, mensagem 853. O Yahoo Grupos foi encerrado em
+dezembro de 2020 e as mensagens não foram preservadas; resta apenas uma
+[cópia arquivada da página do grupo](https://web.archive.org/web/20010522154801/http://groups.yahoo.com/group/vi-br).
 
 Problema: Essa deve ser uma pergunta comum. Suponha o seguinte conteúdo
 de arquivo:
@@ -42,6 +44,6 @@ Observação: 10,20 é o intervalo, ou seja, da linha 10 até a linha 20
 :help pattern
 ```
 O plugin
-[Visincr](http://vim.sourceforge.net/scripts/script.php?script_id=670) 
+[Visincr](https://www.vim.org/scripts/script.php?script_id=670) 
 Possibilita incrementos em modo visual de diversas formas, um vídeo
-demonstrativos pode ser visto [neste link](http://vimeo.com/4457161).
+demonstrativos pode ser visto [neste link](https://vimeo.com/4457161).

--- a/docs/capitulo_6/juncao_de_linhas_com_vim.md
+++ b/docs/capitulo_6/juncao_de_linhas_com_vim.md
@@ -2,7 +2,7 @@
 title: Junção de linhas com Vim
 ---
 
-Fonte: [dicas-l da unicamp](http://www.dicas-l.com.br/dicas-l/20081228.php)
+Fonte: [dicas-l da unicamp](https://www.dicas-l.com.br/arquivo/juncao_de_linhas_com_vim.php)
 Colaboração: Rubens Queiroz de Almeida
 
 Recentemente precisei combinar, em um arquivo, duas linhas consecutivas.

--- a/docs/capitulo_6/usando_expressoes_regulares_em_buscas.md
+++ b/docs/capitulo_6/usando_expressoes_regulares_em_buscas.md
@@ -134,7 +134,7 @@ substituição.
 
 Para aprender mais sobre Expressões Regulares leia:
 
--   [Guia sobre Expressões Regulares](http://guia-er.sourceforge.net)
+-   [Guia sobre Expressões Regulares](https://aurelio.net/regex/guia/)
 
 -   :help regex
 

--- a/docs/capitulo_9/beautifiers.md
+++ b/docs/capitulo_9/beautifiers.md
@@ -5,4 +5,4 @@ arquivo HTML é possível usar a ferramenta "tidy"[^1], do W3C:
 ```
 :%!tidy
 ```
-[^1]: [http://tidy.sourceforge.net/](http://tidy.sourceforge.net/)
+[^1]: [https://www.html-tidy.org/](https://www.html-tidy.org/)

--- a/docs/capitulo_9/indent.md
+++ b/docs/capitulo_9/indent.md
@@ -15,4 +15,4 @@ caracteres extras, mas o procedimento continua o mesmo:
 ```
 :'<,'>!indent
 ```
-[^1]: [http://www.gnu.org/software/indent](http://www.gnu.org/software/indent)
+[^1]: [https://www.gnu.org/software/indent/](https://www.gnu.org/software/indent/)

--- a/docs/capitulo_9/referencias.md
+++ b/docs/capitulo_9/referencias.md
@@ -2,10 +2,10 @@
 title: Referências
 ---
 
--   [http://www.dicas-l.com.br/dicas-l/20070119.php](http://www.dicas-l.com.br/dicas-l/20070119.php)
+-   [https://www.dicas-l.com.br/arquivo/usando_comandos_externos_no_vim_1.php](https://www.dicas-l.com.br/arquivo/usando_comandos_externos_no_vim_1.php)
 
--   [http://vim.wikia.com/wiki/Scientific_calculator](http://vim.wikia.com/wiki/Scientific_calculator)
+-   [https://vim.fandom.com/wiki/Scientific_calculator](https://vim.fandom.com/wiki/Scientific_calculator)
 
--   [http://docs.python.org/library/cmath.html](http://docs.python.org/library/cmath.html)
+-   [https://docs.python.org/3/library/cmath.html](https://docs.python.org/3/library/cmath.html)
 
--   [http://docs.python.org/library/math.html](http://docs.python.org/library/math.html)
+-   [https://docs.python.org/3/library/math.html](https://docs.python.org/3/library/math.html)

--- a/docs/referencias/index.md
+++ b/docs/referencias/index.md
@@ -1,17 +1,17 @@
 
--   [Best of Vim Tips](http://www.rayninfo.co.uk/vimtips.html)
+-   [Best of Vim Tips](https://web.archive.org/web/20260603225804/http://www.rayninfo.co.uk/vimtips.html)
 
 -   [Vim Resources](https://github.com/magnunleno/vim-resources)
 
--   [Vim Bootstrap](http://vim-bootstrap.com/)
+-   [Vim Bootstrap](https://vim-bootstrap.com/)
 
--   [Vim para Noobs](http://woliveiras.com.br/vimparanoobs/)
+-   [Vim para Noobs](https://leanpub.com/vimparanoobs/)
 
--   [Awesome Vim](https://github.com/divad12/vim-awesome)
+-   [Awesome Vim](https://github.com/vim-awesome/vim-awesome)
 
--   [Aurelio .vimrc](http://aurelio.net/vim/vimrc-ivan.txt)
+-   [Aurelio .vimrc](https://aurelio.net/vim/vimrc-ivan.txt)
 
--   [Viva o Tux](http://vivaotux.blogspot.com.br/search/label/vim)
+-   [Viva o Tux](https://vivaotux.blogspot.com/search/label/vim)
 
--   [Original Latex Fonts](http://www.tug.dk/FontCatalogue/seriffonts.html)
+-   [Original Latex Fonts](https://tug.org/FontCatalogue/seriffonts.html)
 


### PR DESCRIPTION
Resolve #48.

Auditei os 84 links externos do livro, conferindo destino a destino em vez de trocar domínio no braço. Como o próprio issue apontava, código HTTP sozinho não conclui nada: os `403` do Fandom e do SourceForge são proteção contra bots (confirmei via API do Fandom que as cinco páginas citadas existem com o mesmo título), e alguns `200` são domínio estacionado.

## Endereços que mudaram de casa

| De | Para |
|---|---|
| `vim.wikia.com/wiki/*` | `vim.fandom.com/wiki/*` |
| `guia-er.sourceforge.net` | `aurelio.net/regex/guia/` |
| `tidy.sourceforge.net` | `html-tidy.org` |
| `ctags.sourceforge.net` | `ctags.io` |
| `vimdoc.sourceforge.net/htmldoc/vimfaq.html` | `vimhelp.org/vim_faq.txt.html` |
| `vim.sourceforge.net/scripts/*` | `www.vim.org/scripts/*` |
| `dicas-l.com.br/dicas-l/AAAAMMDD.php` | `dicas-l.com.br/arquivo/<titulo>.php` |
| `pt-br.libreoffice.org/projetos/vero` | `extensions.libreoffice.org/.../vero-...` |
| `www.tug.dk` | `tug.org` |
| `woliveiras.com.br/vimparanoobs` | `leanpub.com/vimparanoobs` |
| `github.com/divad12/vim-awesome` | `github.com/vim-awesome/vim-awesome` |
| `docs.python.org/library/*` | `docs.python.org/3/library/*` |
| `aurelio.net/doc/vim/txt.vim` | `aurelio.net/vim/txt.vim` |

Duas observações sobre essa tabela:

- O `guia-er.sourceforge.net` não é só um redirecionamento: o site saiu do ar (`guia-er.sourceforge.io/guia-er.html` responde 404). O conteúdo do Aurélio Jargas continua vivo em `aurelio.net/regex/guia/`.
- O Exuberant Ctags parou na versão 5.8, de 2009. O `ctags.io` (Universal Ctags) é o sucessor mantido e é *drop-in replacement*.

## Sem substituto vivo — segui o precedente do `web.archive.org` no `index.md`

- **rayninfo.co.uk** (cap. 5 e página de referências): o domínio nem resolve mais. Aponta para a cópia arquivada.
- **snipt.net** (FindMate, cap. 15): era mesmo o caso levantado no issue. O serviço avisou que fechava em 31/12/2016; hoje o domínio redireciona para o repositório do software Snipt. A cópia arquivada preserva o código do plugin.
- **groups.yahoo.com** (cap. 6): o Yahoo Grupos foi encerrado em dezembro de 2020 e a mensagem 853 nunca foi arquivada — os *snapshots* do grupo param em 2001. Troquei o link por uma frase explicando isso, com link para a cópia arquivada da página do grupo.

## Sem substituto e sem cópia útil

- **`downloads.veryspeedy.net/vim/EasyGrep.gif`**: o arquivo nunca foi arquivado com sucesso (o Wayback só tem o 404). O repositório do plugin tem um screencast equivalente.
- **`screencast.com/t/P6nJkJ0DE`** (plugin `ku`, cap. 15): virou 404 e a cópia arquivada só tem o `.swf` original, que nenhum navegador reproduz hoje. O texto passa a dizer que o vídeo não existe mais e aponta para o repositório do plugin.

## Restante

Onde o próprio site já redirecionava para https, adotei o endereço final. Ficaram em `http` os endereços cujo certificado não valida — `moolenaar.net` tem certificado expirado.

## Verificação

Todos os links foram testados de novo depois das mudanças. Sobraram apenas dois tipos de resposta não-200, ambos conferidos por outro caminho:

- `403` do Fandom e do SourceForge (`vim-latex`): proteção contra bots, páginas existem.
- `www.vim.org` está fora do ar no momento em que escrevo — o Wayback registra `200` em 01/08/2026, então é queda passageira e os `script_id` continuam válidos.

O `zensical build` passa sem avisos.