### PR TITLE
Atualiza a nota de autoria da página inicial

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,4 +27,8 @@ Este trabalho está em constante aprimoramento e é fruto da colaboração de vo
 [Veja como contribuir para o projeto](https://github.com/cassiobotaro/vimbook/blob/main/CONTRIBUTING.md)
 
 !!! note
-    Este livro é apenas a transcrição do [livro original](https://web.archive.org/web/20120525202225/http://code.google.com/p/vimbook/) para [markdown](https://spec.commonmark.org/) e posteriormente utilizando [zensical](https://zensical.org/). Uma lista completa com os autores originais e aqueles que ajudaram na transcrição pode ser encontrada em: [AUTHORS](https://github.com/cassiobotaro/vimbook/blob/main/AUTHORS)
+    Este livro foi escrito em 2009 por um grupo de voluntários. O [livro original](https://web.archive.org/web/20120525202225/http://code.google.com/p/vimbook/) foi transcrito para [markdown](https://spec.commonmark.org/) e esta versão, publicada com o [zensical](https://zensical.org/), é mantida por Cássio Botaro.
+
+    O texto vem sendo revisado desde então: comandos que a transcrição deixou incorretos foram corrigidos, links que morreram nos últimos quinze anos foram atualizados e algumas páginas foram reorganizadas. Por isso esta versão diverge do original em vários pontos, sempre de propósito.
+
+    Os autores originais e quem ajudou na transcrição estão em [AUTHORS](https://github.com/cassiobotaro/vimbook/blob/main/AUTHORS).


### PR DESCRIPTION
A nota da página inicial dizia que este livro é "apenas a transcrição" do original. Isso deixou de ser verdade.

## Por que

Só de correção de comandos são **14 commits**, um por capítulo, cobrindo quase o livro inteiro — coisas como o `nojoinspaces` que estava invertido, funções que não rodavam e nomes de comandos corrompidos na transcrição. Somando as correções de português, a conversão de listas em tabelas, a atualização dos links mortos e a reorganização de páginas que misturavam assuntos, esta versão já diverge do PDF de 2009 em muitos pontos.

Um leitor que comparar as duas e encontrar diferença merece saber que ela é proposital.

Há também um motivo formal: o livro está sob **GFDL**, que exige indicar que a versão foi modificada. A nota antiga afirmava o contrário.

## O que a nota passa a dizer

- de quem é o livro — escrito em 2009 por um grupo de voluntários;
- que esta versão é mantida por outra pessoa, separando quem escreveu de quem mantém;
- o que foi mudado, e que as divergências em relação ao original são deliberadas;
- para onde ir atrás dos créditos completos.

## Sobre a voz

Mantive a terceira pessoa do resto da página, que já fala em "Este trabalho... é fruto da colaboração de voluntários". A alternativa em primeira pessoa ("este livro não é meu") introduziria um narrador que a página nunca apresenta; e a voz passiva pura esconderia quem revisou, que é justamente a informação útil aqui.

## Verificação

`zensical build` passa sem avisos e conferi no HTML gerado que os três parágrafos renderizam dentro do bloco de nota.